### PR TITLE
Nail down whitespace nonsense in rbx_xml

### DIFF
--- a/rbx_xml/src/core.rs
+++ b/rbx_xml/src/core.rs
@@ -3,7 +3,7 @@ use std::io::{Read, Write};
 use rbx_dom_weak::RbxValue;
 
 use crate::{
-    deserializer::{DecodeError, EventIterator},
+    deserializer::{DecodeError, XmlEventReader},
     serializer::{EncodeError, XmlEventWriter},
 };
 
@@ -17,6 +17,6 @@ pub trait XmlType<T: ?Sized> {
     ) -> Result<(), EncodeError>;
 
     fn read_xml<R: Read>(
-        reader: &mut EventIterator<R>,
+        reader: &mut XmlEventReader<R>,
     ) -> Result<RbxValue, DecodeError>;
 }

--- a/rbx_xml/src/deserializer.rs
+++ b/rbx_xml/src/deserializer.rs
@@ -100,8 +100,8 @@ impl<R: Read> EventIterator<R> {
 
     pub fn from_source(source: R) -> EventIterator<R> {
         let reader = ParserConfig::new()
-            .coalesce_characters(true)
-            .cdata_to_characters(true)
+            // .coalesce_characters(true)
+            // .cdata_to_characters(true)
             .ignore_comments(true)
             .create_reader(source);
 
@@ -215,12 +215,7 @@ impl<R: Read> EventIterator<R> {
             }
         });
 
-        let contents = match self.peek() {
-            Some(Ok(XmlReadEvent::Characters(_))) => {
-                read_event!(self, XmlReadEvent::Characters(contents) => contents)
-            }
-            _ => String::new(),
-        };
+        let contents = self.read_characters()?;
 
         read_event!(self, XmlReadEvent::EndElement { .. } => {});
 

--- a/rbx_xml/src/deserializer.rs
+++ b/rbx_xml/src/deserializer.rs
@@ -143,11 +143,17 @@ impl<R: Read> EventIterator<R> {
     pub fn read_tag_contents(&mut self, expected_name: &str) -> Result<String, DecodeError> {
         read_event!(self, XmlReadEvent::StartElement { name, .. } => {
             if name.local_name != expected_name {
-                return Err(DecodeError::Message("got wrong tag name"));
+                return Err(DecodeError::Message("Got wrong tag name"));
             }
         });
 
-        let contents = read_event!(self, XmlReadEvent::Characters(content) => content);
+        let contents = match self.peek() {
+            Some(Ok(XmlReadEvent::Characters(_))) => {
+                read_event!(self, XmlReadEvent::Characters(contents) => contents)
+            }
+            _ => String::new(),
+        };
+
         read_event!(self, XmlReadEvent::EndElement { .. } => {});
 
         Ok(contents)

--- a/rbx_xml/src/lib.rs
+++ b/rbx_xml/src/lib.rs
@@ -14,6 +14,9 @@ mod serializer;
 mod types;
 mod reflection;
 
+#[cfg(test)]
+mod test_util;
+
 pub use crate::{
     serializer::{encode, EncodeError},
     deserializer::{decode, decode_str, DecodeError},

--- a/rbx_xml/src/macros.rs
+++ b/rbx_xml/src/macros.rs
@@ -1,14 +1,11 @@
 #[macro_export]
 macro_rules! read_event {
     {$reader:expr, $xmlevent:pat => $body:expr} => {
-        loop {
-            match $reader.next().ok_or(crate::deserializer::DecodeError::Message("Unexpected EOF"))?? {
-                $xmlevent => break $body,
-                ::xml::reader::XmlEvent::Whitespace(_) => {},
-                invalid => {
-                    ::log::trace!("Expected event {}, got event {:?}", stringify!($xmlevent), invalid);
-                    return Err(crate::deserializer::DecodeError::MalformedDocument);
-                },
+        match $reader.next().ok_or(crate::deserializer::DecodeError::Message("Unexpected EOF"))?? {
+            $xmlevent => $body,
+            invalid => {
+                ::log::trace!("Expected event {}, got event {:?}", stringify!($xmlevent), invalid);
+                return Err(crate::deserializer::DecodeError::MalformedDocument);
             }
         }
     };

--- a/rbx_xml/src/serializer.rs
+++ b/rbx_xml/src/serializer.rs
@@ -75,8 +75,8 @@ impl<W: Write> XmlEventWriter<W> {
     }
 
     pub fn write_string(&mut self, value: &str) -> Result<(), writer::Error> {
-        let first_char = self.character_buffer.chars().next();
-        let last_char = self.character_buffer.chars().next_back();
+        let first_char = value.chars().next();
+        let last_char = value.chars().next_back();
 
         // If the string has leading or trailing whitespace, we switch to
         // writing it as part of a CDATA block instead of a regular characters

--- a/rbx_xml/src/serializer.rs
+++ b/rbx_xml/src/serializer.rs
@@ -56,6 +56,7 @@ pub struct XmlEventWriter<W> {
 }
 
 impl<W: Write> XmlEventWriter<W> {
+    /// Constructs an `XmlEventWriter` from an output that implements `Write`.
     pub fn from_output(output: W) -> XmlEventWriter<W> {
         let inner = EmitterConfig::new()
             .perform_indent(true)
@@ -68,61 +69,76 @@ impl<W: Write> XmlEventWriter<W> {
         }
     }
 
+    /// Writes a single XML event to the output stream.
     pub fn write<'a, E>(&mut self, event: E) -> Result<(), writer::Error>
         where E: Into<XmlWriteEvent<'a>>
     {
         self.inner.write(event)
     }
 
+    /// Writes a string slice to the output stream as characters or CDATA.
     pub fn write_string(&mut self, value: &str) -> Result<(), writer::Error> {
-        let first_char = value.chars().next();
-        let last_char = value.chars().next_back();
-
-        // If the string has leading or trailing whitespace, we switch to
-        // writing it as part of a CDATA block instead of a regular characters
-        // block.
-        let has_outer_whitespace = match (first_char, last_char) {
-            (Some(first), Some(last)) => first.is_whitespace() || last.is_whitespace(),
-            (Some(char), None) | (None, Some(char)) => char.is_whitespace(),
-            (None, None) => false,
-        };
-
-        if has_outer_whitespace {
-            self.inner.write(XmlWriteEvent::cdata(value))?;
-        } else {
-            self.inner.write(XmlWriteEvent::characters(value))?;
-        }
-
-        Ok(())
+        write_characters_or_cdata(&mut self.inner, value)
     }
 
-    /// A more efficient implementation to write characters to the XML output
-    /// stream that reuses a buffer for each string.
+    /// Writes a value that implements `Display` as characters or CDATA. Resuses
+    /// an internal buffer to avoid unnecessary allocations.
     pub fn write_characters<T: std::fmt::Display>(&mut self, value: T) -> Result<(), writer::Error> {
         write!(self.character_buffer, "{}", value).unwrap();
-        self.inner.write(XmlWriteEvent::characters(&self.character_buffer))?;
+        write_characters_or_cdata(&mut self.inner, &self.character_buffer)?;
         self.character_buffer.clear();
 
         Ok(())
     }
 
+    /// The same as `write_characters`, but wraps the characters in a tag with
+    /// the given name and no attributes.
     pub fn write_tag_characters<T: std::fmt::Display>(&mut self, tag: &str, value: T) -> Result<(), writer::Error> {
         self.write(XmlWriteEvent::start_element(tag))?;
         self.write_characters(value)?;
         self.write(XmlWriteEvent::end_element())
     }
 
+    /// Writes a list of values that implement `Display`, with each wrapped in
+    /// an associated tag. This method uses the same optimization as
+    /// `write_characters` to avoid extra allocations.
     pub fn write_tag_array<T: std::fmt::Display>(&mut self, values: &[T], tags: &[&str]) -> Result<(), writer::Error> {
         assert_eq!(values.len(), tags.len());
 
         for (index, component) in values.iter().enumerate() {
-            self.write(XmlWriteEvent::start_element(tags[index]))?;
-            self.write_characters(component)?;
-            self.write(XmlWriteEvent::end_element())?;
+            self.write_tag_characters(tags[index], component)?;
         }
 
         Ok(())
     }
+}
+
+/// Given a value, writes a `Characters` event or a `CData` event depending on
+/// whether the input string contains whitespace that needs to be explicitly
+/// preserved.
+///
+/// This method is extracted so that it can be used inside both `write_string`
+/// and `write_characters` without borrowing issues.
+fn write_characters_or_cdata<W: Write>(writer: &mut EventWriter<W>, value: &str) -> Result<(), writer::Error> {
+    let first_char = value.chars().next();
+    let last_char = value.chars().next_back();
+
+    // If the string has leading or trailing whitespace, we switch to
+    // writing it as part of a CDATA block instead of a regular characters
+    // block.
+    let has_outer_whitespace = match (first_char, last_char) {
+        (Some(first), Some(last)) => first.is_whitespace() || last.is_whitespace(),
+        (Some(char), None) | (None, Some(char)) => char.is_whitespace(),
+        (None, None) => false,
+    };
+
+    if has_outer_whitespace {
+        writer.write(XmlWriteEvent::cdata(value))?;
+    } else {
+        writer.write(XmlWriteEvent::characters(value))?;
+    }
+
+    Ok(())
 }
 
 struct EmitState {
@@ -153,7 +169,7 @@ impl EmitState {
 
 fn serialize_value<W: Write>(
     writer: &mut XmlEventWriter<W>,
-    state: &mut EmitState,
+    _state: &mut EmitState,
     canonical_name: &str,
     value: &RbxValue,
 ) -> Result<(), EncodeError> {
@@ -195,53 +211,4 @@ fn serialize_instance<W: Write>(
     writer.write(XmlWriteEvent::end_element())?;
 
     Ok(())
-}
-
-#[cfg(test)]
-mod test {
-    use super::encode;
-
-    use std::collections::HashMap;
-    use std::str;
-
-    use rbx_dom_weak::{RbxTree, RbxInstanceProperties, RbxValue};
-
-    #[test]
-    fn serialize() {
-        let _ = env_logger::try_init();
-
-        let mut properties = HashMap::new();
-        properties.insert("SomethingEnabled".to_string(), RbxValue::String {
-            value: "Yes Please".to_string(),
-        });
-
-        let root_instance = RbxInstanceProperties {
-            name: "DataModel".to_string(),
-            class_name: "DataModel".to_string(),
-            properties,
-        };
-
-        let mut child_properties = HashMap::new();
-        child_properties.insert("StreamingEnabled".to_string(), RbxValue::Bool {
-            value: true,
-        });
-
-        let child = RbxInstanceProperties {
-            name: "Workspace".to_string(),
-            class_name: "Workspace".to_string(),
-            properties: child_properties,
-        };
-
-        let mut tree = RbxTree::new(root_instance);
-        let root_id = tree.get_root_id();
-        tree.insert_instance(child, root_id);
-
-        let root = tree.get_instance(root_id).unwrap();
-
-        let mut output = Vec::new();
-        encode(&tree, &root.get_children_ids(), &mut output).unwrap();
-        let _as_str = str::from_utf8(&output).unwrap();
-
-        // TODO: Serialize/deserialize and assert output?
-    }
 }

--- a/rbx_xml/src/serializer.rs
+++ b/rbx_xml/src/serializer.rs
@@ -50,6 +50,8 @@ pub fn encode<W: Write>(tree: &RbxTree, ids: &[RbxId], output: W) -> Result<(), 
     Ok(())
 }
 
+/// A wrapper around an xml-rs `EventWriter` as well as other state kept around
+/// for performantly emitting XML.
 pub struct XmlEventWriter<W> {
     inner: EventWriter<W>,
     character_buffer: String,

--- a/rbx_xml/src/serializer.rs
+++ b/rbx_xml/src/serializer.rs
@@ -74,9 +74,7 @@ impl<W: Write> XmlEventWriter<W> {
         self.inner.write(event)
     }
 
-    pub fn write_string<T: std::fmt::Display>(&mut self, value: T) -> Result<(), writer::Error> {
-        write!(self.character_buffer, "{}", value).unwrap();
-
+    pub fn write_string(&mut self, value: &str) -> Result<(), writer::Error> {
         let first_char = self.character_buffer.chars().next();
         let last_char = self.character_buffer.chars().next_back();
 
@@ -90,12 +88,10 @@ impl<W: Write> XmlEventWriter<W> {
         };
 
         if has_outer_whitespace {
-            self.inner.write(XmlWriteEvent::cdata(&self.character_buffer))?;
+            self.inner.write(XmlWriteEvent::cdata(value))?;
         } else {
-            self.inner.write(XmlWriteEvent::characters(&self.character_buffer))?;
+            self.inner.write(XmlWriteEvent::characters(value))?;
         }
-
-        self.character_buffer.clear();
 
         Ok(())
     }

--- a/rbx_xml/src/test_util.rs
+++ b/rbx_xml/src/test_util.rs
@@ -2,7 +2,7 @@ use rbx_dom_weak::RbxValue;
 
 use crate::{
     core::XmlType,
-    deserializer::EventIterator,
+    deserializer::XmlEventReader,
     serializer::XmlEventWriter,
 };
 
@@ -20,7 +20,7 @@ where
 
     println!("{}", std::str::from_utf8(&buffer).unwrap());
 
-    let mut reader = EventIterator::from_source(buffer.as_slice());
+    let mut reader = XmlEventReader::from_source(buffer.as_slice());
     reader.next().unwrap().unwrap(); // Eat StartDocument event
 
     let value = Xml::read_xml(&mut reader).unwrap();
@@ -40,8 +40,8 @@ where
 
     Xml::write_xml(&mut writer, "foo", test_value).unwrap();
 
-    let mut expected_events = EventIterator::from_source(expected_source.as_bytes());
-    let mut actual_events = EventIterator::from_source(buffer.as_slice());
+    let mut expected_events = XmlEventReader::from_source(expected_source.as_bytes());
+    let mut actual_events = XmlEventReader::from_source(buffer.as_slice());
 
     let fail = || panic!(
         "Expected XML:\n{}\n\nActual XML:\n{}",
@@ -77,7 +77,7 @@ where
 {
     let _ = env_logger::try_init();
 
-    let mut reader = EventIterator::from_source(source.as_bytes());
+    let mut reader = XmlEventReader::from_source(source.as_bytes());
     reader.next().unwrap().unwrap(); // Eat StartDocument event
     let value = Xml::read_xml(&mut reader).unwrap();
 

--- a/rbx_xml/src/test_util.rs
+++ b/rbx_xml/src/test_util.rs
@@ -1,0 +1,85 @@
+use rbx_dom_weak::RbxValue;
+
+use crate::{
+    core::XmlType,
+    deserializer::EventIterator,
+    serializer::XmlEventWriter,
+};
+
+pub fn test_xml_round_trip<Xml, InnerType>(test_value: &InnerType, wrapped_value: RbxValue)
+where
+    Xml: XmlType<InnerType>,
+    InnerType: ?Sized,
+{
+    let _ = env_logger::try_init();
+
+    let mut buffer = Vec::new();
+    let mut writer = XmlEventWriter::from_output(&mut buffer);
+
+    Xml::write_xml(&mut writer, "foo", test_value).unwrap();
+
+    println!("{}", std::str::from_utf8(&buffer).unwrap());
+
+    let mut reader = EventIterator::from_source(buffer.as_slice());
+    reader.next().unwrap().unwrap(); // Eat StartDocument event
+
+    let value = Xml::read_xml(&mut reader).unwrap();
+
+    assert_eq!(value, wrapped_value);
+}
+
+pub fn test_xml_serialize<Xml, InnerType>(expected_source: &str, test_value: &InnerType)
+where
+    Xml: XmlType<InnerType>,
+    InnerType: ?Sized,
+{
+    let _ = env_logger::try_init();
+
+    let mut buffer = Vec::new();
+    let mut writer = XmlEventWriter::from_output(&mut buffer);
+
+    Xml::write_xml(&mut writer, "foo", test_value).unwrap();
+
+    let mut expected_events = EventIterator::from_source(expected_source.as_bytes());
+    let mut actual_events = EventIterator::from_source(buffer.as_slice());
+
+    let fail = || panic!(
+        "Expected XML:\n{}\n\nActual XML:\n{}",
+        expected_source,
+        std::str::from_utf8(&buffer).unwrap(),
+    );
+
+    loop {
+        let (expected, actual) = (expected_events.next(), actual_events.next());
+
+        match (expected.is_some(), actual.is_some()) {
+            (true, true) => {
+                if expected != actual {
+                    println!("Expected event: {:#?}", expected);
+                    println!("Actual event: {:#?}", actual);
+
+                    fail();
+                }
+            }
+            (true, false) | (false, true) => {
+                println!("Event streams were different lengths!");
+                fail()
+            },
+            (false, false) => break,
+        }
+    }
+}
+
+pub fn test_xml_deserialize<Xml, InnerType>(source: &str, expected_value: RbxValue)
+where
+    Xml: XmlType<InnerType>,
+    InnerType: ?Sized,
+{
+    let _ = env_logger::try_init();
+
+    let mut reader = EventIterator::from_source(source.as_bytes());
+    reader.next().unwrap().unwrap(); // Eat StartDocument event
+    let value = Xml::read_xml(&mut reader).unwrap();
+
+    assert_eq!(value, expected_value);
+}

--- a/rbx_xml/src/types/binary_string.rs
+++ b/rbx_xml/src/types/binary_string.rs
@@ -62,25 +62,16 @@ impl XmlType<[u8]> for BinaryStringType {
 mod test {
     use super::*;
 
+    use crate::test_util;
+
     #[test]
     fn round_trip_binary_string() {
-        let _ = env_logger::try_init();
+        let test_value = b"\x00\x01hello,\n\x7Fworld, from a fairly sizable binary string literal.\n";
 
-        static TEST_VALUE: &[u8] = b"\x00\x01hello,\n\x7Fworld, from a fairly sizable binary string literal.\n";
+        let wrapped_value = RbxValue::BinaryString {
+            value: test_value.to_vec(),
+        };
 
-        let mut buffer = Vec::new();
-
-        let mut writer = XmlEventWriter::from_output(&mut buffer);
-        BinaryStringType::write_xml(&mut writer, "foo", TEST_VALUE).unwrap();
-
-        println!("{}", std::str::from_utf8(&buffer).unwrap());
-
-        let mut reader = EventIterator::from_source(buffer.as_slice());
-        reader.next().unwrap().unwrap(); // Eat StartDocument event
-        let value = BinaryStringType::read_xml(&mut reader).unwrap();
-
-        assert_eq!(value, RbxValue::BinaryString {
-            value: TEST_VALUE.to_owned(),
-        });
+        test_util::test_xml_round_trip::<BinaryStringType, _>(test_value, wrapped_value);
     }
 }

--- a/rbx_xml/src/types/binary_string.rs
+++ b/rbx_xml/src/types/binary_string.rs
@@ -4,7 +4,7 @@ use rbx_dom_weak::RbxValue;
 
 use crate::{
     core::XmlType,
-    deserializer::{DecodeError, EventIterator},
+    deserializer::{DecodeError, XmlEventReader},
     serializer::{EncodeError, XmlWriteEvent, XmlEventWriter},
 };
 
@@ -26,7 +26,7 @@ impl XmlType<[u8]> for BinaryStringType {
     }
 
     fn read_xml<R: Read>(
-        reader: &mut EventIterator<R>,
+        reader: &mut XmlEventReader<R>,
     ) -> Result<RbxValue, DecodeError> {
         let contents = reader.read_tag_contents(Self::XML_TAG_NAME)?;
 

--- a/rbx_xml/src/types/bool.rs
+++ b/rbx_xml/src/types/bool.rs
@@ -57,23 +57,25 @@ impl XmlType<bool> for BoolType {
 mod test {
     use super::*;
 
+    use crate::test_util;
+
     #[test]
-    fn round_trip() {
-        let _ = env_logger::try_init();
+    fn round_trip_true() {
+        test_util::test_xml_round_trip::<BoolType, _>(
+            &true,
+            RbxValue::Bool {
+                value: true,
+            }
+        );
+    }
 
-        let mut buffer = Vec::new();
-
-        let mut writer = XmlEventWriter::from_output(&mut buffer);
-        BoolType::write_xml(&mut writer, "foo", &true).unwrap();
-
-        println!("{}", std::str::from_utf8(&buffer).unwrap());
-
-        let mut reader = EventIterator::from_source(buffer.as_slice());
-        reader.next().unwrap().unwrap(); // Eat StartDocument event
-        let value = BoolType::read_xml(&mut reader).unwrap();
-
-        assert_eq!(value, RbxValue::Bool {
-            value: true,
-        });
+    #[test]
+    fn round_trip_false() {
+        test_util::test_xml_round_trip::<BoolType, _>(
+            &false,
+            RbxValue::Bool {
+                value: false,
+            }
+        );
     }
 }

--- a/rbx_xml/src/types/bool.rs
+++ b/rbx_xml/src/types/bool.rs
@@ -4,7 +4,7 @@ use rbx_dom_weak::RbxValue;
 
 use crate::{
     core::XmlType,
-    deserializer::{DecodeError, XmlReadEvent, EventIterator},
+    deserializer::{DecodeError, XmlReadEvent, XmlEventReader},
     serializer::{EncodeError, XmlWriteEvent, XmlEventWriter},
 };
 
@@ -33,7 +33,7 @@ impl XmlType<bool> for BoolType {
     }
 
     fn read_xml<R: Read>(
-        reader: &mut EventIterator<R>,
+        reader: &mut XmlEventReader<R>,
     ) -> Result<RbxValue, DecodeError> {
         reader.expect_start_with_name(Self::XML_TAG_NAME)?;
 

--- a/rbx_xml/src/types/cframe.rs
+++ b/rbx_xml/src/types/cframe.rs
@@ -52,29 +52,22 @@ impl XmlType<CFrameValue> for CFrameType {
 mod test {
     use super::*;
 
+    use crate::test_util;
+
     #[test]
     fn round_trip() {
-        let _ = env_logger::try_init();
-
         let test_input: [f32; 12] = [
             123.0, 456.0, 789.0,
             987.0, 654.0, 432.0,
             210.0, 0.0, -12345.0,
             765.0, 234.0, 123123.0,
         ];
-        let mut buffer = Vec::new();
 
-        let mut writer = XmlEventWriter::from_output(&mut buffer);
-        CFrameType::write_xml(&mut writer, "foo", &test_input).unwrap();
-
-        println!("{}", std::str::from_utf8(&buffer).unwrap());
-
-        let mut reader = EventIterator::from_source(buffer.as_slice());
-        reader.next().unwrap().unwrap(); // Eat StartDocument event
-        let value = CFrameType::read_xml(&mut reader).unwrap();
-
-        assert_eq!(value, RbxValue::CFrame {
-            value: test_input,
-        });
+        test_util::test_xml_round_trip::<CFrameType, _>(
+            &test_input,
+            RbxValue::CFrame {
+                value: test_input,
+            }
+        );
     }
 }

--- a/rbx_xml/src/types/cframe.rs
+++ b/rbx_xml/src/types/cframe.rs
@@ -4,7 +4,7 @@ use rbx_dom_weak::RbxValue;
 
 use crate::{
     core::XmlType,
-    deserializer::{DecodeError, EventIterator},
+    deserializer::{DecodeError, XmlEventReader},
     serializer::{EncodeError, XmlWriteEvent, XmlEventWriter},
 };
 
@@ -29,7 +29,7 @@ impl XmlType<CFrameValue> for CFrameType {
     }
 
     fn read_xml<R: Read>(
-        reader: &mut EventIterator<R>,
+        reader: &mut XmlEventReader<R>,
     ) -> Result<RbxValue, DecodeError> {
         reader.expect_start_with_name(Self::XML_TAG_NAME)?;
 

--- a/rbx_xml/src/types/colors.rs
+++ b/rbx_xml/src/types/colors.rs
@@ -4,7 +4,7 @@ use rbx_dom_weak::RbxValue;
 
 use crate::{
     core::XmlType,
-    deserializer::{DecodeError, XmlReadEvent, EventIterator},
+    deserializer::{DecodeError, XmlReadEvent, XmlEventReader},
     serializer::{EncodeError, XmlWriteEvent, XmlEventWriter},
 };
 
@@ -28,7 +28,7 @@ impl XmlType<[f32; 3]> for Color3Type {
     }
 
     fn read_xml<R: Read>(
-        reader: &mut EventIterator<R>,
+        reader: &mut XmlEventReader<R>,
     ) -> Result<RbxValue, DecodeError> {
         reader.expect_start_with_name(Self::XML_TAG_NAME)?;
 
@@ -83,7 +83,7 @@ impl XmlType<[u8; 3]> for Color3uint8Type {
     }
 
     fn read_xml<R: Read>(
-        reader: &mut EventIterator<R>,
+        reader: &mut XmlEventReader<R>,
     ) -> Result<RbxValue, DecodeError> {
         reader.expect_start_with_name(Self::XML_TAG_NAME)?;
 

--- a/rbx_xml/src/types/content.rs
+++ b/rbx_xml/src/types/content.rs
@@ -71,50 +71,28 @@ mod test {
 
     #[test]
     fn round_trip_content_url() {
-        let _ = env_logger::try_init();
-
         let test_value = "url://not/really/a/url";
 
-        let mut buffer = Vec::new();
-
-        let mut writer = XmlEventWriter::from_output(&mut buffer);
-        ContentType::write_xml(&mut writer, "foo", test_value).unwrap();
-
-        println!("{}", std::str::from_utf8(&buffer).unwrap());
-
-        let mut reader = EventIterator::from_source(buffer.as_slice());
-        reader.next().unwrap().unwrap(); // Eat StartDocument event
-        let value = ContentType::read_xml(&mut reader).unwrap();
-
-        assert_eq!(value, RbxValue::Content {
-            value: test_value.to_owned(),
-        });
+        test_util::test_xml_round_trip::<ContentType, _>(
+            test_value,
+            RbxValue::Content {
+                value: test_value.to_owned(),
+            }
+        );
     }
 
     #[test]
     fn round_trip_content_null() {
-        let _ = env_logger::try_init();
-
-        let test_value = "";
-
-        let mut buffer = Vec::new();
-
-        let mut writer = XmlEventWriter::from_output(&mut buffer);
-        ContentType::write_xml(&mut writer, "foo", test_value).unwrap();
-
-        println!("{}", std::str::from_utf8(&buffer).unwrap());
-
-        let mut reader = EventIterator::from_source(buffer.as_slice());
-        reader.next().unwrap().unwrap(); // Eat StartDocument event
-        let value = ContentType::read_xml(&mut reader).unwrap();
-
-        assert_eq!(value, RbxValue::Content {
-            value: test_value.to_owned(),
-        });
+        test_util::test_xml_round_trip::<ContentType, _>(
+            "",
+            RbxValue::Content {
+                value: String::new(),
+            }
+        );
     }
 
     #[test]
-    fn de_content_url() {
+    fn deserialize_content_url() {
         test_util::test_xml_deserialize::<ContentType, _>(
             r#"
                 <Content name="something">
@@ -128,7 +106,21 @@ mod test {
     }
 
     #[test]
-    fn se_content_url() {
+    fn deserialize_content_null() {
+        test_util::test_xml_deserialize::<ContentType, _>(
+            r#"
+                <Content name="something">
+                    <null></null>
+                </Content>
+            "#,
+            RbxValue::Content {
+                value: String::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn serialize_content_url() {
         test_util::test_xml_serialize::<ContentType, _>(
             r#"
                 <Content name="foo">
@@ -140,16 +132,14 @@ mod test {
     }
 
     #[test]
-    fn de_content_null() {
-        test_util::test_xml_deserialize::<ContentType, _>(
+    fn serialize_content_null() {
+        test_util::test_xml_serialize::<ContentType, _>(
             r#"
-                <Content name="something">
+                <Content name="foo">
                     <null></null>
                 </Content>
             "#,
-            RbxValue::Content {
-                value: String::new(),
-            }
+            ""
         );
     }
 }

--- a/rbx_xml/src/types/content.rs
+++ b/rbx_xml/src/types/content.rs
@@ -4,7 +4,7 @@ use rbx_dom_weak::RbxValue;
 
 use crate::{
     core::XmlType,
-    deserializer::{DecodeError, XmlReadEvent, EventIterator},
+    deserializer::{DecodeError, XmlReadEvent, XmlEventReader},
     serializer::{EncodeError, XmlWriteEvent, XmlEventWriter},
 };
 
@@ -36,7 +36,7 @@ impl XmlType<str> for ContentType {
     }
 
     fn read_xml<R: Read>(
-        reader: &mut EventIterator<R>,
+        reader: &mut XmlEventReader<R>,
     ) -> Result<RbxValue, DecodeError> {
         reader.expect_start_with_name(Self::XML_TAG_NAME)?;
 

--- a/rbx_xml/src/types/content.rs
+++ b/rbx_xml/src/types/content.rs
@@ -1,7 +1,4 @@
-use std::{
-    io::{Read, Write},
-    iter::Iterator,
-};
+use std::io::{Read, Write};
 
 use rbx_dom_weak::RbxValue;
 

--- a/rbx_xml/src/types/enumeration.rs
+++ b/rbx_xml/src/types/enumeration.rs
@@ -4,7 +4,7 @@ use rbx_dom_weak::RbxValue;
 
 use crate::{
     core::XmlType,
-    deserializer::{DecodeError, EventIterator},
+    deserializer::{DecodeError, XmlEventReader},
     serializer::{EncodeError, XmlWriteEvent, XmlEventWriter},
 };
 
@@ -26,7 +26,7 @@ impl XmlType<u32> for EnumType {
     }
 
     fn read_xml<R: Read>(
-        reader: &mut EventIterator<R>,
+        reader: &mut XmlEventReader<R>,
     ) -> Result<RbxValue, DecodeError> {
         let value: u32 = reader.read_tag_contents(Self::XML_TAG_NAME)?.parse()?;
 

--- a/rbx_xml/src/types/enumeration.rs
+++ b/rbx_xml/src/types/enumeration.rs
@@ -40,24 +40,15 @@ impl XmlType<u32> for EnumType {
 mod test {
     use super::*;
 
+    use crate::test_util;
+
     #[test]
     fn round_trip() {
-        let _ = env_logger::try_init();
-
-        let test_input: u32 = 4654321;
-        let mut buffer = Vec::new();
-
-        let mut writer = XmlEventWriter::from_output(&mut buffer);
-        EnumType::write_xml(&mut writer, "foo", &test_input).unwrap();
-
-        println!("{}", std::str::from_utf8(&buffer).unwrap());
-
-        let mut reader = EventIterator::from_source(buffer.as_slice());
-        reader.next().unwrap().unwrap(); // Eat StartDocument event
-        let value = EnumType::read_xml(&mut reader).unwrap();
-
-        assert_eq!(value, RbxValue::Enum {
-            value: test_input,
-        });
+        test_util::test_xml_round_trip::<EnumType, _>(
+            &4654321,
+            RbxValue::Enum {
+                value: 4654321,
+            }
+        );
     }
 }

--- a/rbx_xml/src/types/enumeration.rs
+++ b/rbx_xml/src/types/enumeration.rs
@@ -19,7 +19,7 @@ impl XmlType<u32> for EnumType {
         value: &u32,
     ) -> Result<(), EncodeError> {
         writer.write(XmlWriteEvent::start_element(Self::XML_TAG_NAME).attr("name", name))?;
-        writer.write(XmlWriteEvent::characters(&value.to_string()))?;
+        writer.write_characters(*value)?;
         writer.write(XmlWriteEvent::end_element())?;
 
         Ok(())

--- a/rbx_xml/src/types/mod.rs
+++ b/rbx_xml/src/types/mod.rs
@@ -27,7 +27,7 @@ use log::warn;
 
 use crate::{
     core::XmlType,
-    deserializer::{DecodeError, EventIterator},
+    deserializer::{DecodeError, XmlEventReader},
     serializer::{EncodeError, XmlEventWriter},
 };
 
@@ -40,7 +40,7 @@ macro_rules! declare_rbx_types {
         /// Reads a Roblox property value with the given type from the XML event
         /// stream.
         pub fn read_value_xml<R: Read>(
-            reader: &mut EventIterator<R>,
+            reader: &mut XmlEventReader<R>,
             xml_type_name: &str,
         ) -> Result<RbxValue, DecodeError> {
             match xml_type_name {

--- a/rbx_xml/src/types/numbers.rs
+++ b/rbx_xml/src/types/numbers.rs
@@ -21,7 +21,7 @@ macro_rules! number_type {
                 value: &$rust_type,
             ) -> Result<(), EncodeError> {
                 writer.write(XmlWriteEvent::start_element(Self::XML_TAG_NAME).attr("name", name))?;
-                writer.write(XmlWriteEvent::characters(&value.to_string()))?;
+                writer.write_characters(*value)?;
                 writer.write(XmlWriteEvent::end_element())?;
 
                 Ok(())

--- a/rbx_xml/src/types/numbers.rs
+++ b/rbx_xml/src/types/numbers.rs
@@ -49,87 +49,45 @@ number_type!(Int64, Int64Type, i64, "int64");
 mod test {
     use super::*;
 
+    use crate::test_util;
+
     #[test]
     fn round_trip_f32() {
-        let _ = env_logger::try_init();
-
-        let test_input = 123456.0;
-        let mut buffer = Vec::new();
-
-        let mut writer = XmlEventWriter::from_output(&mut buffer);
-        Float32Type::write_xml(&mut writer, "foo", &test_input).unwrap();
-
-        println!("{}", std::str::from_utf8(&buffer).unwrap());
-
-        let mut reader = EventIterator::from_source(buffer.as_slice());
-        reader.next().unwrap().unwrap(); // Eat StartDocument event
-        let value = Float32Type::read_xml(&mut reader).unwrap();
-
-        assert_eq!(value, RbxValue::Float32 {
-            value: test_input,
-        });
+        test_util::test_xml_round_trip::<Float32Type, _>(
+            &123456.0,
+            RbxValue::Float32 {
+                value: 123456.0,
+            }
+        );
     }
 
     #[test]
     fn round_trip_f64() {
-        let _ = env_logger::try_init();
-
-        let test_input = 123456.0;
-        let mut buffer = Vec::new();
-
-        let mut writer = XmlEventWriter::from_output(&mut buffer);
-        Float64Type::write_xml(&mut writer, "foo", &test_input).unwrap();
-
-        println!("{}", std::str::from_utf8(&buffer).unwrap());
-
-        let mut reader = EventIterator::from_source(buffer.as_slice());
-        reader.next().unwrap().unwrap(); // Eat StartDocument event
-        let value = Float64Type::read_xml(&mut reader).unwrap();
-
-        assert_eq!(value, RbxValue::Float64 {
-            value: test_input,
-        });
+        test_util::test_xml_round_trip::<Float64Type, _>(
+            &123456.0,
+            RbxValue::Float64 {
+                value: 123456.0,
+            }
+        );
     }
 
     #[test]
     fn round_trip_i32() {
-        let _ = env_logger::try_init();
-
-        let test_input = -4654321;
-        let mut buffer = Vec::new();
-
-        let mut writer = XmlEventWriter::from_output(&mut buffer);
-        Int32Type::write_xml(&mut writer, "foo", &test_input).unwrap();
-
-        println!("{}", std::str::from_utf8(&buffer).unwrap());
-
-        let mut reader = EventIterator::from_source(buffer.as_slice());
-        reader.next().unwrap().unwrap(); // Eat StartDocument event
-        let value = Int32Type::read_xml(&mut reader).unwrap();
-
-        assert_eq!(value, RbxValue::Int32 {
-            value: test_input,
-        });
+        test_util::test_xml_round_trip::<Int32Type, _>(
+            &-4654321,
+            RbxValue::Int32 {
+                value: -4654321,
+            }
+        );
     }
 
     #[test]
     fn round_trip_i64() {
-        let _ = env_logger::try_init();
-
-        let test_input = 281474976710656;
-        let mut buffer = Vec::new();
-
-        let mut writer = XmlEventWriter::from_output(&mut buffer);
-        Int64Type::write_xml(&mut writer, "foo", &test_input).unwrap();
-
-        println!("{}", std::str::from_utf8(&buffer).unwrap());
-
-        let mut reader = EventIterator::from_source(buffer.as_slice());
-        reader.next().unwrap().unwrap(); // Eat StartDocument event
-        let value = Int64Type::read_xml(&mut reader).unwrap();
-
-        assert_eq!(value, RbxValue::Int64 {
-            value: test_input,
-        });
+        test_util::test_xml_round_trip::<Int64Type, _>(
+            &281474976710656,
+            RbxValue::Int64 {
+                value: 281474976710656,
+            }
+        );
     }
 }

--- a/rbx_xml/src/types/numbers.rs
+++ b/rbx_xml/src/types/numbers.rs
@@ -4,7 +4,7 @@ use rbx_dom_weak::RbxValue;
 
 use crate::{
     core::XmlType,
-    deserializer::{DecodeError, EventIterator},
+    deserializer::{DecodeError, XmlEventReader},
     serializer::{EncodeError, XmlWriteEvent, XmlEventWriter},
 };
 
@@ -28,7 +28,7 @@ macro_rules! number_type {
             }
 
             fn read_xml<R: Read>(
-                reader: &mut EventIterator<R>,
+                reader: &mut XmlEventReader<R>,
             ) -> Result<RbxValue, DecodeError> {
                 let value: $rust_type = reader.read_tag_contents(Self::XML_TAG_NAME)?.parse()?;
 

--- a/rbx_xml/src/types/physical_properties.rs
+++ b/rbx_xml/src/types/physical_properties.rs
@@ -5,7 +5,7 @@ use rbx_dom_weak::{PhysicalProperties, RbxValue};
 use crate::{
     core::XmlType,
     serializer::{EncodeError, XmlEventWriter},
-    deserializer::{DecodeError, EventIterator},
+    deserializer::{DecodeError, XmlEventReader},
 };
 
 pub struct PhysicalPropertiesType;
@@ -24,7 +24,7 @@ impl XmlType<Option<PhysicalProperties>> for PhysicalPropertiesType {
     }
 
     fn read_xml<R: Read>(
-        reader: &mut EventIterator<R>,
+        reader: &mut XmlEventReader<R>,
     ) -> Result<RbxValue, DecodeError> {
         // TODO: Actually read properties
 

--- a/rbx_xml/src/types/referent.rs
+++ b/rbx_xml/src/types/referent.rs
@@ -4,7 +4,7 @@ use rbx_dom_weak::{RbxId, RbxValue};
 
 use crate::{
     core::XmlType,
-    deserializer::{DecodeError, EventIterator},
+    deserializer::{DecodeError, XmlEventReader},
     serializer::{EncodeError, XmlWriteEvent, XmlEventWriter},
 };
 
@@ -31,7 +31,7 @@ impl XmlType<Option<RbxId>> for RefType {
     }
 
     fn read_xml<R: Read>(
-        reader: &mut EventIterator<R>,
+        reader: &mut XmlEventReader<R>,
     ) -> Result<RbxValue, DecodeError> {
         let _ref_contents = reader.read_tag_contents(Self::XML_TAG_NAME)?;
 
@@ -56,7 +56,7 @@ mod test {
         RefType::write_xml(&mut writer, "foo", &test_input).unwrap();
         println!("{}", std::str::from_utf8(&buffer).unwrap());
 
-        let mut reader = EventIterator::from_source(buffer.as_slice());
+        let mut reader = XmlEventReader::from_source(buffer.as_slice());
         reader.next().unwrap().unwrap(); // Eat StartDocument event
         let value = RefType::read_xml(&mut reader).unwrap();
 

--- a/rbx_xml/src/types/strings.rs
+++ b/rbx_xml/src/types/strings.rs
@@ -19,7 +19,7 @@ impl XmlType<str> for StringType {
         value: &str,
     ) -> Result<(), EncodeError> {
         writer.write(XmlWriteEvent::start_element(Self::XML_TAG_NAME).attr("name", name))?;
-        writer.write(XmlWriteEvent::characters(&value))?;
+        writer.write_string(value)?;
         writer.write(XmlWriteEvent::end_element())?;
 
         Ok(())
@@ -47,7 +47,7 @@ impl XmlType<str> for ProtectedStringType {
         value: &str,
     ) -> Result<(), EncodeError> {
         writer.write(XmlWriteEvent::start_element(Self::XML_TAG_NAME).attr("name", name))?;
-        writer.write(XmlWriteEvent::characters(&value))?;
+        writer.write_string(value)?;
         writer.write(XmlWriteEvent::end_element())?;
 
         Ok(())
@@ -89,6 +89,20 @@ mod test {
             value: test_value.to_owned(),
         });
     }
+
+    // TODO: This test fails since CDATA blocks containing only whitespace are
+    // transformed into `Whitespace` events, which gets stripped, instead of
+    // `Characters` events.
+
+    // #[test]
+    // fn round_trip_just_whitespace_string() {
+    //     let test_value = "\n\t";
+    //     let expected_value = RbxValue::String {
+    //         value: test_value.to_owned(),
+    //     };
+
+    //     test_util::test_xml_round_trip::<StringType, _>(test_value, expected_value);
+    // }
 
     #[test]
     fn de_protected_string() {

--- a/rbx_xml/src/types/strings.rs
+++ b/rbx_xml/src/types/strings.rs
@@ -4,7 +4,7 @@ use rbx_dom_weak::RbxValue;
 
 use crate::{
     core::XmlType,
-    deserializer::{DecodeError, XmlReadEvent, EventIterator},
+    deserializer::{DecodeError, EventIterator},
     serializer::{EncodeError, XmlWriteEvent, XmlEventWriter},
 };
 
@@ -28,11 +28,9 @@ impl XmlType<str> for StringType {
     fn read_xml<R: Read>(
         reader: &mut EventIterator<R>,
     ) -> Result<RbxValue, DecodeError> {
-        reader.expect_start_with_name(Self::XML_TAG_NAME)?;
-        let value = read_event!(reader, XmlReadEvent::Characters(value) => RbxValue::String { value: value.to_owned() });
-        reader.expect_end_with_name(Self::XML_TAG_NAME)?;
+        let value = reader.read_tag_contents(Self::XML_TAG_NAME)?;
 
-        Ok(value)
+        Ok(RbxValue::String { value })
     }
 }
 
@@ -56,11 +54,9 @@ impl XmlType<str> for ProtectedStringType {
     fn read_xml<R: Read>(
         reader: &mut EventIterator<R>,
     ) -> Result<RbxValue, DecodeError> {
-        reader.expect_start_with_name(Self::XML_TAG_NAME)?;
-        let value = read_event!(reader, XmlReadEvent::Characters(value) => RbxValue::String { value: value.to_owned() });
-        reader.expect_end_with_name(Self::XML_TAG_NAME)?;
+        let value = reader.read_tag_contents(Self::XML_TAG_NAME)?;
 
-        Ok(value)
+        Ok(RbxValue::String { value })
     }
 }
 
@@ -68,26 +64,44 @@ impl XmlType<str> for ProtectedStringType {
 mod test {
     use super::*;
 
+    use crate::test_util;
+
     #[test]
     fn round_trip_string() {
-        let _ = env_logger::try_init();
-
         let test_value = "Hello,\n\tworld!\n";
-
-        let mut buffer = Vec::new();
-
-        let mut writer = XmlEventWriter::from_output(&mut buffer);
-        StringType::write_xml(&mut writer, "foo", test_value).unwrap();
-
-        println!("{}", std::str::from_utf8(&buffer).unwrap());
-
-        let mut reader = EventIterator::from_source(buffer.as_slice());
-        reader.next().unwrap().unwrap(); // Eat StartDocument event
-        let value = StringType::read_xml(&mut reader).unwrap();
-
-        assert_eq!(value, RbxValue::String {
+        let expected_value = RbxValue::String {
             value: test_value.to_owned(),
-        });
+        };
+
+        test_util::test_xml_round_trip::<StringType, _>(test_value, expected_value);
+    }
+
+    #[test]
+    fn round_trip_empty_string() {
+        let test_value = "";
+        let expected_value = RbxValue::String {
+            value: test_value.to_owned(),
+        };
+
+        test_util::test_xml_round_trip::<StringType, _>(test_value, expected_value);
+    }
+
+    #[test]
+    fn serialize_simple_string() {
+        test_util::test_xml_serialize::<StringType, _>(
+            r#"
+                <string name="foo">Hello!</string>
+            "#,
+            "Hello!"
+        );
+    }
+
+    #[test]
+    fn serialize_sensitive_whitespace_string() {
+        test_util::test_xml_serialize::<StringType, _>(
+            "<string name=\"foo\"><![CDATA[hello\n]]></string>",
+            "hello\n"
+        );
     }
 
     // TODO: This test fails since CDATA blocks containing only whitespace are
@@ -106,17 +120,16 @@ mod test {
 
     #[test]
     fn de_protected_string() {
-        let _ = env_logger::try_init();
-
         let test_value = "Hello,\n\tworld!\n";
-        let source = format!("<ProtectedString name=\"foo\">{}</ProtectedString>", test_value);
+        let test_source = format!(r#"
+            <ProtectedString name="something">{}</ProtectedString>
+        "#, test_value);
 
-        let mut reader = EventIterator::from_source(source.as_bytes());
-        reader.next().unwrap().unwrap(); // Eat StartDocument event
-        let value = ProtectedStringType::read_xml(&mut reader).unwrap();
-
-        assert_eq!(value, RbxValue::String {
-            value: test_value.to_owned(),
-        });
+        test_util::test_xml_deserialize::<ProtectedStringType, _>(
+            &test_source,
+            RbxValue::String {
+                value: test_value.to_owned(),
+            }
+        );
     }
 }

--- a/rbx_xml/src/types/strings.rs
+++ b/rbx_xml/src/types/strings.rs
@@ -4,7 +4,7 @@ use rbx_dom_weak::RbxValue;
 
 use crate::{
     core::XmlType,
-    deserializer::{DecodeError, EventIterator},
+    deserializer::{DecodeError, XmlEventReader},
     serializer::{EncodeError, XmlWriteEvent, XmlEventWriter},
 };
 
@@ -26,7 +26,7 @@ impl XmlType<str> for StringType {
     }
 
     fn read_xml<R: Read>(
-        reader: &mut EventIterator<R>,
+        reader: &mut XmlEventReader<R>,
     ) -> Result<RbxValue, DecodeError> {
         let value = reader.read_tag_contents(Self::XML_TAG_NAME)?;
 
@@ -52,7 +52,7 @@ impl XmlType<str> for ProtectedStringType {
     }
 
     fn read_xml<R: Read>(
-        reader: &mut EventIterator<R>,
+        reader: &mut XmlEventReader<R>,
     ) -> Result<RbxValue, DecodeError> {
         let value = reader.read_tag_contents(Self::XML_TAG_NAME)?;
 

--- a/rbx_xml/src/types/strings.rs
+++ b/rbx_xml/src/types/strings.rs
@@ -104,19 +104,15 @@ mod test {
         );
     }
 
-    // TODO: This test fails since CDATA blocks containing only whitespace are
-    // transformed into `Whitespace` events, which gets stripped, instead of
-    // `Characters` events.
+    #[test]
+    fn round_trip_just_whitespace_string() {
+        let test_value = "\n\t";
+        let expected_value = RbxValue::String {
+            value: test_value.to_owned(),
+        };
 
-    // #[test]
-    // fn round_trip_just_whitespace_string() {
-    //     let test_value = "\n\t";
-    //     let expected_value = RbxValue::String {
-    //         value: test_value.to_owned(),
-    //     };
-
-    //     test_util::test_xml_round_trip::<StringType, _>(test_value, expected_value);
-    // }
+        test_util::test_xml_round_trip::<StringType, _>(test_value, expected_value);
+    }
 
     #[test]
     fn de_protected_string() {

--- a/rbx_xml/src/types/udims.rs
+++ b/rbx_xml/src/types/udims.rs
@@ -90,83 +90,61 @@ impl XmlType<UDim2Value> for UDim2Type {
 mod test {
     use super::*;
 
+    use crate::test_util;
+
     #[test]
     fn round_trip_udim() {
-        let _ = env_logger::try_init();
-
         let test_input = (0.5, 1);
-        let mut buffer = Vec::new();
 
-        let mut writer = XmlEventWriter::from_output(&mut buffer);
-        UDimType::write_xml(&mut writer, "foo", &test_input).unwrap();
-
-        let mut reader = EventIterator::from_source(buffer.as_slice());
-        reader.next().unwrap().unwrap(); // Eat StartDocument event
-        let value = UDimType::read_xml(&mut reader).unwrap();
-
-        assert_eq!(value, RbxValue::UDim {
-            value: test_input,
-        });
+        test_util::test_xml_round_trip::<UDimType, _>(
+            &test_input,
+            RbxValue::UDim {
+                value: test_input,
+            }
+        );
     }
 
     #[test]
     fn round_trip_udim2() {
-        let _ = env_logger::try_init();
-
         let test_input = (0.5, 1, 1.5, 2);
-        let mut buffer = Vec::new();
 
-        let mut writer = XmlEventWriter::from_output(&mut buffer);
-        UDim2Type::write_xml(&mut writer, "foo", &test_input).unwrap();
-
-        let mut reader = EventIterator::from_source(buffer.as_slice());
-        reader.next().unwrap().unwrap(); // Eat StartDocument event
-        let value = UDim2Type::read_xml(&mut reader).unwrap();
-
-        assert_eq!(value, RbxValue::UDim2 {
-            value: test_input,
-        });
+        test_util::test_xml_round_trip::<UDim2Type, _>(
+            &test_input,
+            RbxValue::UDim2 {
+                value: test_input,
+            }
+        );
     }
 
     #[test]
     fn de_udim() {
-        let _ = env_logger::try_init();
-
-        let buffer = r#"
-            <UDim>
-                <S>0.5</S>
-                <O>1</O>
-            </UDim>
-        "#;
-
-        let mut reader = EventIterator::from_source(buffer.as_bytes());
-        reader.next().unwrap().unwrap(); // Eat StartDocument event
-        let value = UDimType::read_xml(&mut reader).unwrap();
-
-        assert_eq!(value, RbxValue::UDim {
-            value: (0.5, 1),
-        });
+        test_util::test_xml_deserialize::<UDimType, _>(
+            r#"
+                <UDim>
+                    <S>0.5</S>
+                    <O>1</O>
+                </UDim>
+            "#,
+            RbxValue::UDim {
+                value: (0.5, 1),
+            }
+        );
     }
 
     #[test]
     fn de_udim2() {
-        let _ = env_logger::try_init();
-
-        let buffer = r#"
-            <UDim2>
-                <XS>0.5</XS>
-                <XO>1</XO>
-                <YS>1.5</YS>
-                <YO>2</YO>
-            </UDim2>
-        "#;
-
-        let mut reader = EventIterator::from_source(buffer.as_bytes());
-        reader.next().unwrap().unwrap(); // Eat StartDocument event
-        let value = UDim2Type::read_xml(&mut reader).unwrap();
-
-        assert_eq!(value, RbxValue::UDim2 {
-            value: (0.5, 1, 1.5, 2),
-        });
+        test_util::test_xml_deserialize::<UDim2Type, _>(
+            r#"
+                <UDim2>
+                    <XS>0.5</XS>
+                    <XO>1</XO>
+                    <YS>1.5</YS>
+                    <YO>2</YO>
+                </UDim2>
+            "#,
+            RbxValue::UDim2 {
+                value: (0.5, 1, 1.5, 2),
+            }
+        );
     }
 }

--- a/rbx_xml/src/types/udims.rs
+++ b/rbx_xml/src/types/udims.rs
@@ -4,7 +4,7 @@ use rbx_dom_weak::RbxValue;
 
 use crate::{
     core::XmlType,
-    deserializer::{DecodeError, EventIterator},
+    deserializer::{DecodeError, XmlEventReader},
     serializer::{EncodeError, XmlWriteEvent, XmlEventWriter},
 };
 
@@ -30,7 +30,7 @@ impl XmlType<UDimValue> for UDimType {
     }
 
     fn read_xml<R: Read>(
-        reader: &mut EventIterator<R>,
+        reader: &mut XmlEventReader<R>,
     ) -> Result<RbxValue, DecodeError> {
         reader.expect_start_with_name(Self::XML_TAG_NAME)?;
 
@@ -69,7 +69,7 @@ impl XmlType<UDim2Value> for UDim2Type {
     }
 
     fn read_xml<R: Read>(
-        reader: &mut EventIterator<R>,
+        reader: &mut XmlEventReader<R>,
     ) -> Result<RbxValue, DecodeError> {
         reader.expect_start_with_name(Self::XML_TAG_NAME)?;
 

--- a/rbx_xml/src/types/vectors.rs
+++ b/rbx_xml/src/types/vectors.rs
@@ -4,7 +4,7 @@ use rbx_dom_weak::RbxValue;
 
 use crate::{
     core::XmlType,
-    deserializer::{DecodeError, EventIterator},
+    deserializer::{DecodeError, XmlEventReader},
     serializer::{EncodeError, XmlWriteEvent, XmlEventWriter},
 };
 
@@ -29,7 +29,7 @@ impl XmlType<[f32; 2]> for Vector2Type {
     }
 
     fn read_xml<R: Read>(
-        reader: &mut EventIterator<R>,
+        reader: &mut XmlEventReader<R>,
     ) -> Result<RbxValue, DecodeError> {
         reader.expect_start_with_name(Self::XML_TAG_NAME)?;
 
@@ -62,7 +62,7 @@ impl XmlType<[i16; 2]> for Vector2int16Type {
     }
 
     fn read_xml<R: Read>(
-        reader: &mut EventIterator<R>,
+        reader: &mut XmlEventReader<R>,
     ) -> Result<RbxValue, DecodeError> {
         reader.expect_start_with_name(Self::XML_TAG_NAME)?;
 
@@ -95,7 +95,7 @@ impl XmlType<[f32; 3]> for Vector3Type {
     }
 
     fn read_xml<R: Read>(
-        reader: &mut EventIterator<R>,
+        reader: &mut XmlEventReader<R>,
     ) -> Result<RbxValue, DecodeError> {
         reader.expect_start_with_name(Self::XML_TAG_NAME)?;
 
@@ -129,7 +129,7 @@ impl XmlType<[i16; 3]> for Vector3int16Type {
     }
 
     fn read_xml<R: Read>(
-        reader: &mut EventIterator<R>,
+        reader: &mut XmlEventReader<R>,
     ) -> Result<RbxValue, DecodeError> {
         reader.expect_start_with_name(Self::XML_TAG_NAME)?;
 

--- a/rbx_xml/src/types/vectors.rs
+++ b/rbx_xml/src/types/vectors.rs
@@ -149,87 +149,53 @@ impl XmlType<[i16; 3]> for Vector3int16Type {
 mod test {
     use super::*;
 
+    use crate::test_util;
+
     #[test]
     fn round_trip_vector2() {
-        let _ = env_logger::try_init();
-
         let test_input: [f32; 2] = [123.0, 456.0];
-        let mut buffer = Vec::new();
 
-        let mut writer = XmlEventWriter::from_output(&mut buffer);
-        Vector2Type::write_xml(&mut writer, "foo", &test_input).unwrap();
-
-        println!("{}", std::str::from_utf8(&buffer).unwrap());
-
-        let mut reader = EventIterator::from_source(buffer.as_slice());
-        reader.next().unwrap().unwrap(); // Eat StartDocument event
-        let value = Vector2Type::read_xml(&mut reader).unwrap();
-
-        assert_eq!(value, RbxValue::Vector2 {
-            value: test_input,
-        });
+        test_util::test_xml_round_trip::<Vector2Type, _>(
+            &test_input,
+            RbxValue::Vector2 {
+                value: test_input,
+            }
+        );
     }
 
     #[test]
     fn round_trip_vector2int16() {
-        let _ = env_logger::try_init();
+        let test_input: [i16; 2] = [1234, 4567];
 
-        let test_input: [i16; 2] = [12345, -24321];
-        let mut buffer = Vec::new();
-
-        let mut writer = XmlEventWriter::from_output(&mut buffer);
-        Vector2int16Type::write_xml(&mut writer, "foo", &test_input).unwrap();
-
-        println!("{}", std::str::from_utf8(&buffer).unwrap());
-
-        let mut reader = EventIterator::from_source(buffer.as_slice());
-        reader.next().unwrap().unwrap(); // Eat StartDocument event
-        let value = Vector2int16Type::read_xml(&mut reader).unwrap();
-
-        assert_eq!(value, RbxValue::Vector2int16 {
-            value: test_input,
-        });
+        test_util::test_xml_round_trip::<Vector2int16Type, _>(
+            &test_input,
+            RbxValue::Vector2int16 {
+                value: test_input,
+            }
+        );
     }
 
     #[test]
     fn round_trip_vector3() {
-        let _ = env_logger::try_init();
+        let test_input: [f32; 3] = [123.0, 456.0, 7890.0];
 
-        let test_input: [f32; 3] = [123.0, 456.0, -52349.0];
-        let mut buffer = Vec::new();
-
-        let mut writer = XmlEventWriter::from_output(&mut buffer);
-        Vector3Type::write_xml(&mut writer, "foo", &test_input).unwrap();
-
-        println!("{}", std::str::from_utf8(&buffer).unwrap());
-
-        let mut reader = EventIterator::from_source(buffer.as_slice());
-        reader.next().unwrap().unwrap(); // Eat StartDocument event
-        let value = Vector3Type::read_xml(&mut reader).unwrap();
-
-        assert_eq!(value, RbxValue::Vector3 {
-            value: test_input,
-        });
+        test_util::test_xml_round_trip::<Vector3Type, _>(
+            &test_input,
+            RbxValue::Vector3 {
+                value: test_input,
+            }
+        );
     }
 
     #[test]
     fn round_trip_vector3int16() {
-        let _ = env_logger::try_init();
+        let test_input: [i16; 3] = [1234, 4567, 8913];
 
-        let test_input: [i16; 3] = [12345, -24321, 321];
-        let mut buffer = Vec::new();
-
-        let mut writer = XmlEventWriter::from_output(&mut buffer);
-        Vector3int16Type::write_xml(&mut writer, "foo", &test_input).unwrap();
-
-        println!("{}", std::str::from_utf8(&buffer).unwrap());
-
-        let mut reader = EventIterator::from_source(buffer.as_slice());
-        reader.next().unwrap().unwrap(); // Eat StartDocument event
-        let value = Vector3int16Type::read_xml(&mut reader).unwrap();
-
-        assert_eq!(value, RbxValue::Vector3int16 {
-            value: test_input,
-        });
+        test_util::test_xml_round_trip::<Vector3int16Type, _>(
+            &test_input,
+            RbxValue::Vector3int16 {
+                value: test_input,
+            }
+        );
     }
 }


### PR DESCRIPTION
Maaan, dealing with whitespace in XML is a huge pain it turns out.

This PR:
- Fixes emitting strings that having trailing or leading whitespace by wrapping them in CDATA blocks
- Adds expanded tests relying on whitespace invariance
- Adds utilities for describing deserialization, serialization, and round trip tests, including a failing example