### PR TITLE
Refs in rbx_xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Roblox reflection information for working with Instances in external tooling.
 | QFont              | `Studio.Font`                   | ⛔ | ⛔ | ⛔ |
 | Ray                | `RayValue.Value`                | ✔ | ❌ | ❌ |
 | Rect               | `ImageButton.SliceCenter`       | ✔ | ✔ | ❌ |
-| Ref                | `Model.PrimaryPart`             | ✔ | ➖ | ❌ |
+| Ref                | `Model.PrimaryPart`             | ✔ | ✔ | ❌ |
 | Region3            | `N/A`                           | ❌ | ❌ | ❌ |
 | Region3int16       | `Terrain.MaxExtents`            | ❌ | ❌ | ❌ |
 | String             | `Instance.Name`                 | ✔ | ✔ | ✔ |

--- a/rbx_xml/src/deserializer.rs
+++ b/rbx_xml/src/deserializer.rs
@@ -77,7 +77,10 @@ pub fn decode<R: Read>(tree: &mut RbxTree, parent_id: RbxId, source: R) -> Resul
     let mut iterator = XmlEventReader::from_source(source);
     let mut state = ParseState::new(tree);
 
-    deserialize_root(&mut iterator, &mut state, parent_id)
+    deserialize_root(&mut iterator, &mut state, parent_id)?;
+    apply_id_rewrites(&mut state);
+
+    Ok(())
 }
 
 /// Since this function type needs to be mentioned a couple times, we keep this
@@ -268,10 +271,17 @@ impl<R: Read> Iterator for XmlEventReader<R> {
     }
 }
 
+struct IdPropertyRewrite {
+    pub id: RbxId,
+    pub property_name: String,
+    pub referent_value: String,
+}
+
 /// The state needed to deserialize an XML model into an `RbxTree`.
-struct ParseState<'a> {
+pub struct ParseState<'a> {
     referents: HashMap<String, RbxId>,
     metadata: HashMap<String, String>,
+    rewrite_ids: Vec<IdPropertyRewrite>,
     tree: &'a mut RbxTree,
 }
 
@@ -280,8 +290,33 @@ impl<'a> ParseState<'a> {
         ParseState {
             referents: HashMap::new(),
             metadata: HashMap::new(),
+            rewrite_ids: Vec::new(),
             tree,
         }
+    }
+
+    pub fn add_id_rewrite(&mut self, id: RbxId, property_name: String, referent_value: String) {
+        self.rewrite_ids.push(IdPropertyRewrite {
+            id,
+            property_name,
+            referent_value,
+        });
+    }
+}
+
+fn apply_id_rewrites(state: &mut ParseState) {
+    for rewrite in &state.rewrite_ids {
+        let new_value = match state.referents.get(&rewrite.referent_value) {
+            Some(id) => *id,
+            None => continue
+        };
+
+        let instance = state.tree.get_instance_mut(rewrite.id)
+            .expect("rbx_xml bug: had ID in referent map that didn't end up in the tree");
+
+        instance.properties.insert(rewrite.property_name.clone(), RbxValue::Ref {
+            value: Some(new_value),
+        });
     }
 }
 
@@ -430,7 +465,7 @@ fn deserialize_instance<R: Read>(
         match reader.peek().ok_or(DecodeError::Message("Unexpected EOF"))? {
             Ok(XmlReadEvent::StartElement { name, .. }) => match name.local_name.as_str() {
                 "Properties" => {
-                    deserialize_properties(reader, &mut properties)?;
+                    deserialize_properties(reader, state, instance_id, &mut properties)?;
                 },
                 "Item" => {
                     deserialize_instance(reader, state, instance_id)?;
@@ -467,6 +502,8 @@ fn deserialize_instance<R: Read>(
 
 fn deserialize_properties<R: Read>(
     reader: &mut XmlEventReader<R>,
+    state: &mut ParseState,
+    instance_id: RbxId,
     props: &mut HashMap<String, RbxValue>,
 ) -> Result<(), DecodeError> {
     read_event!(reader, XmlReadEvent::StartElement { name, .. } => {
@@ -509,7 +546,7 @@ fn deserialize_properties<R: Read>(
             .map(|value| value.to_string())
             .unwrap_or(xml_property_name);
 
-        let value = read_value_xml(reader, &property_type)?;
+        let value = read_value_xml(reader, &property_type, &canonical_name, instance_id, state)?;
 
         props.insert(canonical_name, value);
     }

--- a/rbx_xml/src/deserializer.rs
+++ b/rbx_xml/src/deserializer.rs
@@ -11,7 +11,7 @@ use xml::reader::{self, ParserConfig};
 
 use crate::{
     reflection::XML_TO_CANONICAL_NAME,
-    types::read_value_xml,
+    types::{read_value_xml, read_ref},
 };
 
 pub use xml::reader::XmlEvent as XmlReadEvent;
@@ -546,7 +546,10 @@ fn deserialize_properties<R: Read>(
             .map(|value| value.to_string())
             .unwrap_or(xml_property_name);
 
-        let value = read_value_xml(reader, &property_type, &canonical_name, instance_id, state)?;
+        let value = match property_type.as_str() {
+            "Ref" => read_ref(reader, instance_id, &canonical_name, state)?,
+            _ => read_value_xml(reader, &property_type)?
+        };
 
         props.insert(canonical_name, value);
     }

--- a/rbx_xml/src/serializer.rs
+++ b/rbx_xml/src/serializer.rs
@@ -179,6 +179,8 @@ fn serialize_value<W: Write>(
         .get(canonical_name)
         .unwrap_or(&canonical_name);
 
+    // Refs need additional state that we don't want to thread through
+    // `write_value_xml`, so we handle it here.
     match value {
         RbxValue::Ref { value } => write_ref(writer, xml_name, value, state),
         _ => write_value_xml(writer, xml_name, value)

--- a/rbx_xml/src/serializer.rs
+++ b/rbx_xml/src/serializer.rs
@@ -10,7 +10,7 @@ use rbx_dom_weak::{RbxTree, RbxValue, RbxId};
 
 use crate::{
     reflection::CANONICAL_TO_XML_NAME,
-    types::write_value_xml,
+    types::{write_value_xml, write_ref},
 };
 
 pub use xml::writer::XmlEvent as XmlWriteEvent;
@@ -179,7 +179,10 @@ fn serialize_value<W: Write>(
         .get(canonical_name)
         .unwrap_or(&canonical_name);
 
-    write_value_xml(writer, xml_name, value, state)
+    match value {
+        RbxValue::Ref { value } => write_ref(writer, xml_name, value, state),
+        _ => write_value_xml(writer, xml_name, value)
+    }
 }
 
 fn serialize_instance<W: Write>(

--- a/rbx_xml/src/serializer.rs
+++ b/rbx_xml/src/serializer.rs
@@ -143,7 +143,7 @@ fn write_characters_or_cdata<W: Write>(writer: &mut EventWriter<W>, value: &str)
     Ok(())
 }
 
-struct EmitState {
+pub struct EmitState {
     referent_map: HashMap<RbxId, u32>,
     next_referent: u32,
 }
@@ -171,7 +171,7 @@ impl EmitState {
 
 fn serialize_value<W: Write>(
     writer: &mut XmlEventWriter<W>,
-    _state: &mut EmitState,
+    state: &mut EmitState,
     canonical_name: &str,
     value: &RbxValue,
 ) -> Result<(), EncodeError> {
@@ -179,7 +179,7 @@ fn serialize_value<W: Write>(
         .get(canonical_name)
         .unwrap_or(&canonical_name);
 
-    write_value_xml(writer, xml_name, value)
+    write_value_xml(writer, xml_name, value, state)
 }
 
 fn serialize_instance<W: Write>(

--- a/rbx_xml/src/types/mod.rs
+++ b/rbx_xml/src/types/mod.rs
@@ -26,14 +26,16 @@ mod vectors;
 
 use std::io::{Read, Write};
 
-use rbx_dom_weak::{RbxId, RbxValue};
+use rbx_dom_weak::RbxValue;
 use log::warn;
 
 use crate::{
     core::XmlType,
-    deserializer::{DecodeError, XmlEventReader, ParseState},
-    serializer::{EncodeError, XmlEventWriter, EmitState},
+    deserializer::{DecodeError, XmlEventReader},
+    serializer::{EncodeError, XmlEventWriter},
 };
+
+pub use self::referent::{read_ref, write_ref};
 
 /// The `declare_rbx_types` macro generates the two big match statements that
 /// rbx_xml uses to read/write values inside of `read_value_xml` and
@@ -46,14 +48,9 @@ macro_rules! declare_rbx_types {
         pub fn read_value_xml<R: Read>(
             reader: &mut XmlEventReader<R>,
             xml_type_name: &str,
-            property_name: &str,
-            instance_id: RbxId,
-            state: &mut ParseState,
         ) -> Result<RbxValue, DecodeError> {
             match xml_type_name {
                 $(<$typedef>::XML_TAG_NAME => <$typedef>::read_xml(reader),)*
-
-                self::referent::XML_TAG_NAME => self::referent::read_ref(reader, instance_id, property_name, state),
 
                 // Protected strings are only read, never written
                 self::strings::ProtectedStringType::XML_TAG_NAME => self::strings::ProtectedStringType::read_xml(reader),
@@ -71,12 +68,9 @@ macro_rules! declare_rbx_types {
             writer: &mut XmlEventWriter<W>,
             xml_property_name: &str,
             value: &RbxValue,
-            state: &mut EmitState,
         ) -> Result<(), EncodeError> {
             match value {
                 $(RbxValue::$rbx_type { value } => <$typedef>::write_xml(writer, xml_property_name, value),)*
-
-                RbxValue::Ref { value } => self::referent::write_ref(writer, xml_property_name, value, state),
 
                 unknown => {
                     warn!("Property value {:?} cannot be serialized yet", unknown);

--- a/rbx_xml/src/types/referent.rs
+++ b/rbx_xml/src/types/referent.rs
@@ -1,3 +1,14 @@
+//! Referents are strange compared to other property types.
+//!
+//! Refs require extra information, which is why they aren't part of the
+//! `XmlType`-implementing family of structs like other types. I think this is
+//! a better approach than widening the values that `XmlType` accepts just for
+//! this type.
+//!
+//! Specifically, deserializing refs needs access to a special list of
+//! 'rewrites'. It's used as part of a second pass to make sure that refs
+//! pointing to instances that we haven't reached yet work okay.
+
 use std::io::{Read, Write};
 
 use rbx_dom_weak::{RbxId, RbxValue};
@@ -36,6 +47,11 @@ pub fn read_ref<R: Read>(
     let ref_contents = reader.read_tag_contents(XML_TAG_NAME)?;
 
     if ref_contents != "null" {
+        // We need to rewrite this property as part of a follow-up pass.
+        //
+        // We might not know which ID this referent points to yet, so instead of
+        // trying to handle the case where we do here, we just let all referents
+        // get written later.
         state.add_id_rewrite(id, property_name.to_owned(), ref_contents);
     }
 


### PR DESCRIPTION
Closes #12.

This ended up being pretty hairy relative to introducing other property types.

Every time we encounter a Ref property, keep track of the instance's ID, the property name, and the referent the property is being set to. Because we can encounter instances in any order, we might not know what instance the referent points to yet, and rbx\_dom\_weak explicitly doesn't let you pick what IDs your instances get.

After we've deserialized all instances and their properties, we step through the table of 'ID rewrites', with one entry per non-null Ref property. We find the instance with the given ID (which should always exist) as well as which ID the referent value points to. If the referent points to an instance that ended up actually existing, we insert our freshly minted Ref property.