### PR TITLE
Stabilize RbxValue::try_convert_ref API

### DIFF
--- a/rbx_dom_weak/src/value.rs
+++ b/rbx_dom_weak/src/value.rs
@@ -193,23 +193,29 @@ impl RbxValue {
     /// already the right type.
     ///
     /// If the conversion wasn't successful, returns `None`.
-    pub fn try_convert_ref<'a>(&'a self, target_type: RbxValueType) -> Option<Cow<'a, RbxValue>> {
+    pub fn try_convert_ref<'a>(&'a self, target_type: RbxValueType) -> RbxValueConversion {
         if self.get_type() == target_type {
-            return Some(Cow::Borrowed(self))
+            return RbxValueConversion::Unnecessary;
         }
 
         // TODO: Reduce duplication with try_convert
 
         match (self, target_type) {
-            (RbxValue::Float32 { value }, RbxValueType::Float64) => Some(Cow::Owned(RbxValue::Float64 { value: *value as f64 })),
-            (RbxValue::Float64 { value }, RbxValueType::Float32) => Some(Cow::Owned(RbxValue::Float32 { value: *value as f32 })),
+            (RbxValue::Float32 { value }, RbxValueType::Float64) => RbxValueConversion::Converted(RbxValue::Float64 { value: *value as f64 }),
+            (RbxValue::Float64 { value }, RbxValueType::Float32) => RbxValueConversion::Converted(RbxValue::Float32 { value: *value as f32 }),
 
-            (RbxValue::Int32 { value }, RbxValueType::Int64) => Some(Cow::Owned(RbxValue::Int64 { value: *value as i64 })),
-            (RbxValue::Int64 { value }, RbxValueType::Int32) => Some(Cow::Owned(RbxValue::Int32 { value: *value as i32 })),
+            (RbxValue::Int32 { value }, RbxValueType::Int64) => RbxValueConversion::Converted(RbxValue::Int64 { value: *value as i64 }),
+            (RbxValue::Int64 { value }, RbxValueType::Int32) => RbxValueConversion::Converted(RbxValue::Int32 { value: *value as i32 }),
 
-            (_this, _) => None
+            (_this, _) => RbxValueConversion::Failed
         }
     }
+}
+
+pub enum RbxValueConversion {
+    Converted(RbxValue),
+    Unnecessary,
+    Failed,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/rbx_dom_weak/src/value.rs
+++ b/rbx_dom_weak/src/value.rs
@@ -170,7 +170,7 @@ impl RbxValue {
     /// Is a no-op if the value is already of the correct type.
     ///
     /// If the conversion fails, the value will be given back in the `Err` case.
-    pub fn try_convert(self, target_type: RbxValueType) -> Result<RbxValue, RbxValue> {
+    fn try_convert(self, target_type: RbxValueType) -> Result<RbxValue, RbxValue> {
         if self.get_type() == target_type {
             return Ok(self)
         }

--- a/rbx_xml/src/deserializer.rs
+++ b/rbx_xml/src/deserializer.rs
@@ -7,7 +7,7 @@ use std::{
 use failure::Fail;
 use log::trace;
 use rbx_reflection::RbxPropertyTypeDescriptor;
-use rbx_dom_weak::{RbxTree, RbxId, RbxInstanceProperties, RbxValue, RbxValueType};
+use rbx_dom_weak::{RbxTree, RbxId, RbxInstanceProperties, RbxValue, RbxValueType, RbxValueConversion};
 use xml::reader::{self, ParserConfig};
 
 use crate::{
@@ -567,8 +567,8 @@ fn deserialize_properties<R: Read>(
                     };
 
                     let value = match xml_value.try_convert_ref(value_type) {
-                        Some(value) => value.into_owned(),
-                        None => xml_value,
+                        RbxValueConversion::Converted(value) => value,
+                        RbxValueConversion::Unnecessary | RbxValueConversion::Failed => xml_value,
                     };
 
                     value

--- a/rbx_xml/src/deserializer.rs
+++ b/rbx_xml/src/deserializer.rs
@@ -566,9 +566,9 @@ fn deserialize_properties<R: Read>(
                         RbxPropertyTypeDescriptor::UnimplementedType(_) => xml_value.get_type(),
                     };
 
-                    let value = match xml_value.try_convert(value_type) {
-                        Ok(value) => value,
-                        Err(value) => value,
+                    let value = match xml_value.try_convert_ref(value_type) {
+                        Some(value) => value.into_owned(),
+                        None => xml_value,
                     };
 
                     value


### PR DESCRIPTION
Closes #36.

I think we can get away with removing `try_convert` and only supporting `try_convert_ref`. In the worst case, it incurs a copy conversion, which I think might be fine if we can make it only happen in the conversion case.