### PR TITLE
Implement RbxTree::move_instance and shore up other DOM methods

### DIFF
--- a/rbx_dom_weak/CHANGELOG.md
+++ b/rbx_dom_weak/CHANGELOG.md
@@ -1,6 +1,7 @@
 # rbx\_dom\_weak Changelog
 
 ## Unreleased Changes
+* Added `RbxTree::move_instance` API to move instances from one tree to another.
 * Fixed `RbxTree::descendants` to no longer return the instance of the ID you give it. This may break code relying on this (broken) assumption, but was definitely a bug.
 
 ## 1.5.0 (2019-05-06)

--- a/rbx_dom_weak/src/tree.rs
+++ b/rbx_dom_weak/src/tree.rs
@@ -70,7 +70,8 @@ impl RbxTree {
 
         // Remove the instance we're trying to move and manually rewrite its
         // parent.
-        let mut root_instance = self.instances.remove(&source_id).unwrap();
+        let mut root_instance = self.instances.remove(&source_id)
+            .expect("Cannot move an instance that does not exist in the tree");
         root_instance.parent = Some(dest_parent_id);
 
         let mut to_visit = root_instance.children.clone();

--- a/rbx_dom_weak/src/tree.rs
+++ b/rbx_dom_weak/src/tree.rs
@@ -280,4 +280,54 @@ mod test {
         assert!(seen_ids.contains(&b_id));
         assert!(seen_ids.contains(&c_id));
     }
+
+    #[test]
+    fn move_instances() {
+        let mut source_tree = RbxTree::new(RbxInstanceProperties {
+            name: "Place 1".to_owned(),
+            class_name: "DataModel".to_owned(),
+            properties: HashMap::new(),
+        });
+
+        let source_root_id = source_tree.get_root_id();
+
+        let a_id = source_tree.insert_instance(RbxInstanceProperties {
+            name: "A".to_owned(),
+            class_name: "Folder".to_owned(),
+            properties: HashMap::new(),
+        }, source_root_id);
+
+        let b_id = source_tree.insert_instance(RbxInstanceProperties {
+            name: "B".to_owned(),
+            class_name: "Folder".to_owned(),
+            properties: HashMap::new(),
+        }, a_id);
+
+        let c_id = source_tree.insert_instance(RbxInstanceProperties {
+            name: "C".to_owned(),
+            class_name: "Folder".to_owned(),
+            properties: HashMap::new(),
+        }, a_id);
+
+        let mut dest_tree = RbxTree::new(RbxInstanceProperties {
+            name: "Place 2".to_owned(),
+            class_name: "DataModel".to_owned(),
+            properties: HashMap::new(),
+        });
+
+        let dest_root_id = dest_tree.get_root_id();
+
+        source_tree.move_instance(a_id, &mut dest_tree, dest_root_id);
+
+        assert!(source_tree.get_instance(a_id).is_none());
+        assert!(source_tree.get_instance(b_id).is_none());
+        assert!(source_tree.get_instance(c_id).is_none());
+        assert_eq!(source_tree.get_instance(source_root_id).unwrap().get_children_ids().len(), 0);
+
+        assert!(dest_tree.get_instance(a_id).is_some());
+        assert!(dest_tree.get_instance(b_id).is_some());
+        assert!(dest_tree.get_instance(c_id).is_some());
+        assert_eq!(dest_tree.get_instance(dest_root_id).unwrap().get_children_ids().len(), 1);
+        assert_eq!(dest_tree.get_instance(a_id).unwrap().get_children_ids(), &[b_id, c_id]);
+    }
 }


### PR DESCRIPTION
This PR adds `RbxTree::move_instance`, which is a new-and-improved version of the old `transplant` method from pre-1.0 versions of rbx\_dom\_weak.

This paves the way to start adding more things onto `RbxTree`, like metadata and the shared string dictionary. We can then adjust the `rbx_xml` and `rbx_binary` APIs to instead return entire trees instead of decoding into trees in-place. This simplifies their APIs and makes everything easier to reason about, especially in failure cases!