### PR TITLE
New rbx_xml API

### DIFF
--- a/generate_reflection/src/run_in_roblox.rs
+++ b/generate_reflection/src/run_in_roblox.rs
@@ -146,7 +146,7 @@ pub fn run_in_roblox(plugin: &RbxTree) -> Vec<Vec<u8>> {
         let root_id = place.get_root_id();
         let top_level_ids = place.get_instance(root_id).unwrap().get_children_ids();
 
-        rbx_xml::encode(&place, top_level_ids, &mut place_file)
+        rbx_xml::to_writer(&place, top_level_ids, &mut place_file)
             .expect("Could not serialize temporary place file to disk");
     }
 
@@ -156,7 +156,7 @@ pub fn run_in_roblox(plugin: &RbxTree) -> Vec<Vec<u8>> {
 
         let root_id = plugin.get_root_id();
 
-        rbx_xml::encode(&plugin, &[root_id], &mut plugin_file)
+        rbx_xml::to_writer(&plugin, &[root_id], &mut plugin_file)
             .expect("Could not serialize plugin file to disk");
     }
 

--- a/generate_reflection/src/run_in_roblox.rs
+++ b/generate_reflection/src/run_in_roblox.rs
@@ -146,7 +146,7 @@ pub fn run_in_roblox(plugin: &RbxTree) -> Vec<Vec<u8>> {
         let root_id = place.get_root_id();
         let top_level_ids = place.get_instance(root_id).unwrap().get_children_ids();
 
-        rbx_xml::to_writer(&place, top_level_ids, &mut place_file)
+        rbx_xml::to_writer_default(&mut place_file, &place, top_level_ids)
             .expect("Could not serialize temporary place file to disk");
     }
 
@@ -156,7 +156,7 @@ pub fn run_in_roblox(plugin: &RbxTree) -> Vec<Vec<u8>> {
 
         let root_id = plugin.get_root_id();
 
-        rbx_xml::to_writer(&plugin, &[root_id], &mut plugin_file)
+        rbx_xml::to_writer_default(&mut plugin_file, &plugin, &[root_id])
             .expect("Could not serialize plugin file to disk");
     }
 

--- a/rbx_xml/src/deserializer.rs
+++ b/rbx_xml/src/deserializer.rs
@@ -38,6 +38,8 @@ impl DecodeOptions {
     /// types present in the model/place file instead of ones modified for
     /// consumption. This leaks details of the format, but can be useful for
     /// debugging.
+    // TODO: Make this public once this setting actually does anything.
+    #[allow(unused)]
     fn use_reflection(self, use_reflection: bool) -> DecodeOptions {
         DecodeOptions {
             use_reflection,

--- a/rbx_xml/src/deserializer.rs
+++ b/rbx_xml/src/deserializer.rs
@@ -15,6 +15,20 @@ use crate::{
 
 use crate::deserializer_core::{XmlEventReader, XmlReadEvent};
 
+pub fn from_reader<R: Read>(source: R) -> Result<RbxTree, NewDecodeError> {
+    let mut tree = RbxTree::new(RbxInstanceProperties {
+        class_name: "DataModel".to_owned(),
+        name: "DataModel".to_owned(),
+        properties: HashMap::new(),
+    });
+
+    let root_id = tree.get_root_id();
+
+    decode(&mut tree, root_id, source)?;
+
+    Ok(tree)
+}
+
 /// A utility method to decode an XML-format model from a string.
 pub fn decode_str(tree: &mut RbxTree, parent_id: RbxId, source: &str) -> Result<(), NewDecodeError> {
     decode(tree, parent_id, source.as_bytes())

--- a/rbx_xml/src/deserializer.rs
+++ b/rbx_xml/src/deserializer.rs
@@ -15,8 +15,7 @@ use crate::{
 
 use crate::deserializer_core::{XmlEventReader, XmlReadEvent};
 
-/// Describes the options available to tweak how to deserialize an XML-format
-/// model or place.
+/// Options available for deserializing an XML-format model or place.
 #[derive(Debug, Clone)]
 pub struct DecodeOptions {
     use_reflection: bool,

--- a/rbx_xml/src/deserializer.rs
+++ b/rbx_xml/src/deserializer.rs
@@ -15,6 +15,24 @@ use crate::{
 
 use crate::deserializer_core::{XmlEventReader, XmlReadEvent};
 
+pub fn decode_internal<R: Read>(source: R, _options: DecodeOptions) -> Result<RbxTree, NewDecodeError> {
+    let mut tree = RbxTree::new(RbxInstanceProperties {
+        class_name: "DataModel".to_owned(),
+        name: "DataModel".to_owned(),
+        properties: HashMap::new(),
+    });
+
+    let root_id = tree.get_root_id();
+
+    let mut iterator = XmlEventReader::from_source(source);
+    let mut state = ParseState::new(&mut tree);
+
+    deserialize_root(&mut iterator, &mut state, root_id)?;
+    apply_id_rewrites(&mut state);
+
+    Ok(tree)
+}
+
 /// Options available for deserializing an XML-format model or place.
 #[derive(Debug, Clone)]
 pub struct DecodeOptions {
@@ -52,24 +70,6 @@ impl Default for DecodeOptions {
     fn default() -> DecodeOptions {
         DecodeOptions::new()
     }
-}
-
-pub fn decode_internal<R: Read>(source: R, _options: DecodeOptions) -> Result<RbxTree, NewDecodeError> {
-    let mut tree = RbxTree::new(RbxInstanceProperties {
-        class_name: "DataModel".to_owned(),
-        name: "DataModel".to_owned(),
-        properties: HashMap::new(),
-    });
-
-    let root_id = tree.get_root_id();
-
-    let mut iterator = XmlEventReader::from_source(source);
-    let mut state = ParseState::new(&mut tree);
-
-    deserialize_root(&mut iterator, &mut state, root_id)?;
-    apply_id_rewrites(&mut state);
-
-    Ok(tree)
 }
 
 struct IdPropertyRewrite {

--- a/rbx_xml/src/error.rs
+++ b/rbx_xml/src/error.rs
@@ -5,8 +5,7 @@ use std::{
 
 use rbx_dom_weak::RbxValueType;
 
-/// Describes an error that can occur when deserializing an XML-format model or
-/// place.
+/// An error that can occur when deserializing an XML-format model or place.
 #[derive(Debug)]
 pub struct DecodeError {
     // This indirection drops the size of the error type substantially (~150
@@ -144,8 +143,7 @@ impl From<base64::DecodeError> for DecodeErrorKind {
     }
 }
 
-/// Describes an error that can occur when serializing an XML-format model or
-/// place.
+/// An error that can occur when serializing an XML-format model or place.
 #[derive(Debug)]
 pub struct EncodeError {
     // This Box helps reduce the size of EncodeError a lot, which is important.

--- a/rbx_xml/src/lib.rs
+++ b/rbx_xml/src/lib.rs
@@ -15,8 +15,51 @@ mod types;
 #[cfg(test)]
 mod test_util;
 
-pub use crate::{
-    serializer::to_writer,
-    deserializer::{from_reader, from_str},
-    error::{EncodeError, DecodeError},
+use std::io::{Read, Write};
+
+use rbx_dom_weak::{RbxTree, RbxId};
+
+use crate::{
+    deserializer::decode_internal,
+    serializer::encode_internal,
 };
+
+pub use crate::{
+    error::{EncodeError, DecodeError},
+    deserializer::DecodeOptions,
+    serializer::EncodeOptions,
+};
+
+/// Decodes an XML-format model or place from anything that implements the
+/// `std::io::Read` trait.
+pub fn from_reader<R: Read>(reader: R, options: DecodeOptions) -> Result<RbxTree, DecodeError> {
+    decode_internal(reader, options)
+}
+
+/// Decodes an XML-format model or place from anything that implements the
+/// `std::io::Read` trait.
+pub fn from_reader_default<R: Read>(reader: R) -> Result<RbxTree, DecodeError> {
+    decode_internal(reader, DecodeOptions::default())
+}
+
+/// Decodes an XML-format model or place from a string.
+pub fn from_str<S: AsRef<str>>(reader: S, options: DecodeOptions) -> Result<RbxTree, DecodeError> {
+    decode_internal(reader.as_ref().as_bytes(), options)
+}
+
+/// Decodes an XML-format model or place from a string.
+pub fn from_str_default<S: AsRef<str>>(reader: S) -> Result<RbxTree, DecodeError> {
+    decode_internal(reader.as_ref().as_bytes(), DecodeOptions::default())
+}
+
+/// Serializes a subset of the given tree to an XML format model or place,
+/// writing to something that implements the `std::io::Write` trait.
+pub fn to_writer<W: Write>(writer: W, tree: &RbxTree, ids: &[RbxId], options: EncodeOptions) -> Result<(), EncodeError> {
+    encode_internal(writer, tree, ids, options)
+}
+
+/// Serializes a subset of the given tree to an XML format model or place,
+/// writing to something that implements the `std::io::Write` trait.
+pub fn to_writer_default<W: Write>(writer: W, tree: &RbxTree, ids: &[RbxId]) -> Result<(), EncodeError> {
+    encode_internal(writer, tree, ids, EncodeOptions::default())
+}

--- a/rbx_xml/src/lib.rs
+++ b/rbx_xml/src/lib.rs
@@ -16,7 +16,7 @@ mod types;
 mod test_util;
 
 pub use crate::{
-    serializer::encode,
-    deserializer::{decode, decode_str},
+    serializer::to_writer,
+    deserializer::{from_reader, from_str},
     error::{EncodeError, DecodeError},
 };

--- a/rbx_xml/src/lib.rs
+++ b/rbx_xml/src/lib.rs
@@ -1,6 +1,12 @@
-//! XML format (rbxmx and rbxlx) serializer and deserializer for rbx-dom.
+//! Configurable Roblox XML place/model format (rbxmx and rbxlx) serializer and
+//! deserializer.
 //!
-//! Implements most types, and is driven by an up-to-date reflection database.
+//! rbx_xml uses the [rbx_dom_weak][rbx_dom_weak] crate as its DOM.
+//!
+//! This crate implements most of the format and is driven by an up-to-date
+//! reflection database.
+//!
+//! [rbx_dom_weak]: https://crates.io/crates/rbx_dom_weak
 
 #![deny(missing_docs)]
 
@@ -30,14 +36,14 @@ pub use crate::{
     serializer::EncodeOptions,
 };
 
-/// Decodes an XML-format model or place from anything that implements the
+/// Decodes an XML-format model or place from something that implements the
 /// `std::io::Read` trait.
 pub fn from_reader<R: Read>(reader: R, options: DecodeOptions) -> Result<RbxTree, DecodeError> {
     decode_internal(reader, options)
 }
 
-/// Decodes an XML-format model or place from anything that implements the
-/// `std::io::Read` trait.
+/// Decodes an XML-format model or place from something that implements the
+/// `std::io::Read` trait using the default decoder options.
 pub fn from_reader_default<R: Read>(reader: R) -> Result<RbxTree, DecodeError> {
     decode_internal(reader, DecodeOptions::default())
 }
@@ -47,7 +53,8 @@ pub fn from_str<S: AsRef<str>>(reader: S, options: DecodeOptions) -> Result<RbxT
     decode_internal(reader.as_ref().as_bytes(), options)
 }
 
-/// Decodes an XML-format model or place from a string.
+/// Decodes an XML-format model or place from a string using the default decoder
+/// options.
 pub fn from_str_default<S: AsRef<str>>(reader: S) -> Result<RbxTree, DecodeError> {
     decode_internal(reader.as_ref().as_bytes(), DecodeOptions::default())
 }
@@ -59,7 +66,8 @@ pub fn to_writer<W: Write>(writer: W, tree: &RbxTree, ids: &[RbxId], options: En
 }
 
 /// Serializes a subset of the given tree to an XML format model or place,
-/// writing to something that implements the `std::io::Write` trait.
+/// writing to something that implements the `std::io::Write` trait using the
+/// default encoder options.
 pub fn to_writer_default<W: Write>(writer: W, tree: &RbxTree, ids: &[RbxId]) -> Result<(), EncodeError> {
     encode_internal(writer, tree, ids, EncodeOptions::default())
 }

--- a/rbx_xml/src/serializer.rs
+++ b/rbx_xml/src/serializer.rs
@@ -15,13 +15,7 @@ use crate::{
 
 use crate::serializer_core::{XmlEventWriter, XmlWriteEvent};
 
-/// Serializes a subset of the given tree to an XML format model or place,
-/// writing to something that implements the `std::io::Write` trait.
-pub fn to_writer<W: Write>(tree: &RbxTree, ids: &[RbxId], output: W) -> Result<(), NewEncodeError> {
-    encode_internal(tree, ids, output)
-}
-
-fn encode_internal<W: Write>(tree: &RbxTree, ids: &[RbxId], output: W) -> Result<(), NewEncodeError> {
+pub fn encode_internal<W: Write>(output: W, tree: &RbxTree, ids: &[RbxId], _options: EncodeOptions) -> Result<(), NewEncodeError> {
     let mut writer = XmlEventWriter::from_output(output);
     let mut state = EmitState::new();
 
@@ -34,6 +28,43 @@ fn encode_internal<W: Write>(tree: &RbxTree, ids: &[RbxId], output: W) -> Result
     writer.write(XmlWriteEvent::end_element())?;
 
     Ok(())
+}
+
+/// Describes the options available to tweak how to serialize an XML-format
+/// model or place.
+#[derive(Debug, Clone)]
+pub struct EncodeOptions {
+    use_reflection: bool,
+}
+
+impl EncodeOptions {
+    /// Constructs a `EncodeOptions` with all values set to their defaults.
+    pub fn new() -> EncodeOptions {
+        EncodeOptions {
+            use_reflection: true,
+        }
+    }
+
+    /// Enabled by default.
+    ///
+    /// Sets whether to use the reflection database to canonicalize fields and
+    /// value types.
+    ///
+    /// If disabled, properties will be written as-is to the disk. Files
+    /// produced this way will probably not be compatible with Roblox unless
+    /// they were read with the same option in `DecodeOptions`.
+    fn use_reflection(self, use_reflection: bool) -> EncodeOptions {
+        EncodeOptions {
+            use_reflection,
+            ..self
+        }
+    }
+}
+
+impl Default for EncodeOptions {
+    fn default() -> EncodeOptions {
+        EncodeOptions::new()
+    }
 }
 
 pub struct EmitState {

--- a/rbx_xml/src/serializer.rs
+++ b/rbx_xml/src/serializer.rs
@@ -15,9 +15,13 @@ use crate::{
 
 use crate::serializer_core::{XmlEventWriter, XmlWriteEvent};
 
-/// Serialize the instances denoted by `ids` from `tree` as an XML-format model,
-/// writing to `output`.
-pub fn encode<W: Write>(tree: &RbxTree, ids: &[RbxId], output: W) -> Result<(), NewEncodeError> {
+/// Serializes a subset of the given tree to an XML format model or place,
+/// writing to something that implements the `std::io::Write` trait.
+pub fn to_writer<W: Write>(tree: &RbxTree, ids: &[RbxId], output: W) -> Result<(), NewEncodeError> {
+    encode_internal(tree, ids, output)
+}
+
+fn encode_internal<W: Write>(tree: &RbxTree, ids: &[RbxId], output: W) -> Result<(), NewEncodeError> {
     let mut writer = XmlEventWriter::from_output(output);
     let mut state = EmitState::new();
 

--- a/rbx_xml/src/serializer.rs
+++ b/rbx_xml/src/serializer.rs
@@ -52,6 +52,8 @@ impl EncodeOptions {
     /// If disabled, properties will be written as-is to the disk. Files
     /// produced this way will probably not be compatible with Roblox unless
     /// they were read with the same option in `DecodeOptions`.
+    // TODO: Make this public once this setting actually does anything.
+    #[allow(unused)]
     fn use_reflection(self, use_reflection: bool) -> EncodeOptions {
         EncodeOptions {
             use_reflection,

--- a/rbx_xml/src/serializer.rs
+++ b/rbx_xml/src/serializer.rs
@@ -30,8 +30,7 @@ pub fn encode_internal<W: Write>(output: W, tree: &RbxTree, ids: &[RbxId], _opti
     Ok(())
 }
 
-/// Describes the options available to tweak how to serialize an XML-format
-/// model or place.
+/// Options available for serializing an XML-format model or place.
 #[derive(Debug, Clone)]
 pub struct EncodeOptions {
     use_reflection: bool,

--- a/rbx_xml/tests/deserializer_legacy.rs
+++ b/rbx_xml/tests/deserializer_legacy.rs
@@ -1,9 +1,7 @@
 //! This file has tests ported out of the deserializer that should be broken
 //! apart and refactored eventually.
 
-use std::collections::HashMap;
-
-use rbx_dom_weak::{RbxTree, RbxInstanceProperties, RbxValue};
+use rbx_dom_weak::RbxValue;
 
 fn floats_approx_equal(left: f32, right: f32, epsilon: f32) -> bool {
     (left - right).abs() <= epsilon
@@ -14,7 +12,7 @@ fn empty_document() {
     let _ = env_logger::try_init();
     let document = r#"<roblox version="4"></roblox>"#;
 
-    rbx_xml::from_str(document).unwrap();
+    rbx_xml::from_str_default(document).unwrap();
 }
 
 #[test]
@@ -27,7 +25,7 @@ fn mostly_empty() {
         </roblox>
     "#;
 
-    rbx_xml::from_str(document).unwrap();
+    rbx_xml::from_str_default(document).unwrap();
 }
 
 #[test]
@@ -39,7 +37,7 @@ fn top_level_garbage() {
         </roblox>
     "#;
 
-    assert!(rbx_xml::from_str(document).is_err());
+    assert!(rbx_xml::from_str_default(document).is_err());
 }
 
 #[test]
@@ -52,7 +50,7 @@ fn empty_instance() {
         </roblox>
     "#;
 
-    let tree = rbx_xml::from_str(document).unwrap();
+    let tree = rbx_xml::from_str_default(document).unwrap();
 
     let root = tree.get_instance(tree.get_root_id()).unwrap();
     assert_eq!(root.get_children_ids().len(), 1);
@@ -76,7 +74,7 @@ fn children() {
         </roblox>
     "#;
 
-    let tree = rbx_xml::from_str(document).unwrap();
+    let tree = rbx_xml::from_str_default(document).unwrap();
     let root_id = tree.get_root_id();
     let root = tree.get_instance(root_id).unwrap();
     let first_folder = tree.get_instance(root.get_children_ids()[0]).expect("expected a child");
@@ -102,7 +100,7 @@ fn canonicalized_names() {
         </roblox>
     "#;
 
-    let tree = rbx_xml::from_str(document).unwrap();
+    let tree = rbx_xml::from_str_default(document).unwrap();
     let root_id = tree.get_root_id();
 
     let root_instance = tree.get_instance(root_id).unwrap();
@@ -126,7 +124,7 @@ fn with_bool() {
         </roblox>
     "#;
 
-    let tree = rbx_xml::from_str(document).unwrap();
+    let tree = rbx_xml::from_str_default(document).unwrap();
     let root_id = tree.get_root_id();
 
     let root_instance = tree.get_instance(root_id).unwrap();
@@ -155,7 +153,7 @@ fn with_vector3() {
         </roblox>
     "#;
 
-    let tree = rbx_xml::from_str(document).unwrap();
+    let tree = rbx_xml::from_str_default(document).unwrap();
     let root_id = tree.get_root_id();
 
     let root_instance = tree.get_instance(root_id).unwrap();
@@ -190,7 +188,7 @@ fn with_color3() {
         </roblox>
     "#;
 
-    let tree = rbx_xml::from_str(document).unwrap();
+    let tree = rbx_xml::from_str_default(document).unwrap();
     let root_id = tree.get_root_id();
 
     for descendant in tree.descendants(root_id) {
@@ -222,7 +220,7 @@ fn with_color3uint8() {
         </roblox>
     "#;
 
-    let tree = rbx_xml::from_str(document).unwrap();
+    let tree = rbx_xml::from_str_default(document).unwrap();
     let root_id = tree.get_root_id();
 
     let root_instance = tree.get_instance(root_id).unwrap();
@@ -260,7 +258,7 @@ fn with_cframe() {
         </roblox>
     "#;
 
-    let tree = rbx_xml::from_str(document).unwrap();
+    let tree = rbx_xml::from_str_default(document).unwrap();
     let root_id = tree.get_root_id();
 
     let root_instance = tree.get_instance(root_id).unwrap();
@@ -295,7 +293,7 @@ fn with_ref_some() {
         </roblox>
     "#;
 
-    let tree = rbx_xml::from_str(document).unwrap();
+    let tree = rbx_xml::from_str_default(document).unwrap();
     let root_id = tree.get_root_id();
 
     let root_instance = tree.get_instance(root_id).unwrap();
@@ -328,7 +326,7 @@ fn with_ref_none() {
         </roblox>
     "#;
 
-    let tree = rbx_xml::from_str(document).unwrap();
+    let tree = rbx_xml::from_str_default(document).unwrap();
     let root_id = tree.get_root_id();
 
     let root_instance = tree.get_instance(root_id).unwrap();

--- a/rbx_xml/tests/deserializer_legacy.rs
+++ b/rbx_xml/tests/deserializer_legacy.rs
@@ -4,17 +4,6 @@
 use std::collections::HashMap;
 
 use rbx_dom_weak::{RbxTree, RbxInstanceProperties, RbxValue};
-use rbx_xml::decode_str;
-
-fn new_data_model() -> RbxTree {
-    let root = RbxInstanceProperties {
-        name: "DataModel".to_string(),
-        class_name: "DataModel".to_string(),
-        properties: HashMap::new(),
-    };
-
-    RbxTree::new(root)
-}
 
 fn floats_approx_equal(left: f32, right: f32, epsilon: f32) -> bool {
     (left - right).abs() <= epsilon
@@ -24,10 +13,8 @@ fn floats_approx_equal(left: f32, right: f32, epsilon: f32) -> bool {
 fn empty_document() {
     let _ = env_logger::try_init();
     let document = r#"<roblox version="4"></roblox>"#;
-    let mut tree = new_data_model();
-    let root_id = tree.get_root_id();
 
-    decode_str(&mut tree, root_id, document).unwrap();
+    rbx_xml::from_str(document).unwrap();
 }
 
 #[test]
@@ -40,10 +27,7 @@ fn mostly_empty() {
         </roblox>
     "#;
 
-    let mut tree = new_data_model();
-    let root_id = tree.get_root_id();
-
-    decode_str(&mut tree, root_id, document).unwrap();
+    rbx_xml::from_str(document).unwrap();
 }
 
 #[test]
@@ -55,10 +39,7 @@ fn top_level_garbage() {
         </roblox>
     "#;
 
-    let mut tree = new_data_model();
-    let root_id = tree.get_root_id();
-
-    assert!(decode_str(&mut tree, root_id, document).is_err());
+    assert!(rbx_xml::from_str(document).is_err());
 }
 
 #[test]
@@ -71,12 +52,9 @@ fn empty_instance() {
         </roblox>
     "#;
 
-    let mut tree = new_data_model();
-    let root_id = tree.get_root_id();
+    let tree = rbx_xml::from_str(document).unwrap();
 
-    decode_str(&mut tree, root_id, document).unwrap();
-
-    let root = tree.get_instance(root_id).unwrap();
+    let root = tree.get_instance(tree.get_root_id()).unwrap();
     assert_eq!(root.get_children_ids().len(), 1);
 }
 
@@ -98,10 +76,8 @@ fn children() {
         </roblox>
     "#;
 
-    let mut tree = new_data_model();
+    let tree = rbx_xml::from_str(document).unwrap();
     let root_id = tree.get_root_id();
-
-    decode_str(&mut tree, root_id, document).unwrap();
     let root = tree.get_instance(root_id).unwrap();
     let first_folder = tree.get_instance(root.get_children_ids()[0]).expect("expected a child");
     let inner_folder = tree.get_instance(first_folder.get_children_ids()[0]).expect("expected a subchild");
@@ -126,10 +102,8 @@ fn canonicalized_names() {
         </roblox>
     "#;
 
-    let mut tree = new_data_model();
+    let tree = rbx_xml::from_str(document).unwrap();
     let root_id = tree.get_root_id();
-
-    decode_str(&mut tree, root_id, document).expect("should work D:");
 
     let root_instance = tree.get_instance(root_id).unwrap();
     let descendant = tree.get_instance(root_instance.get_children_ids()[0]).unwrap();
@@ -152,10 +126,8 @@ fn with_bool() {
         </roblox>
     "#;
 
-    let mut tree = new_data_model();
+    let tree = rbx_xml::from_str(document).unwrap();
     let root_id = tree.get_root_id();
-
-    decode_str(&mut tree, root_id, document).expect("should work D:");
 
     let root_instance = tree.get_instance(root_id).unwrap();
     let descendant = tree.get_instance(root_instance.get_children_ids()[0]).unwrap();
@@ -183,10 +155,8 @@ fn with_vector3() {
         </roblox>
     "#;
 
-    let mut tree = new_data_model();
+    let tree = rbx_xml::from_str(document).unwrap();
     let root_id = tree.get_root_id();
-
-    decode_str(&mut tree, root_id, document).expect("should work D:");
 
     let root_instance = tree.get_instance(root_id).unwrap();
     let descendant = tree.get_instance(root_instance.get_children_ids()[0]).unwrap();
@@ -220,10 +190,8 @@ fn with_color3() {
         </roblox>
     "#;
 
-    let mut tree = new_data_model();
+    let tree = rbx_xml::from_str(document).unwrap();
     let root_id = tree.get_root_id();
-
-    decode_str(&mut tree, root_id, document).unwrap();
 
     for descendant in tree.descendants(root_id) {
         if descendant.name == "Test" {
@@ -254,10 +222,8 @@ fn with_color3uint8() {
         </roblox>
     "#;
 
-    let mut tree = new_data_model();
+    let tree = rbx_xml::from_str(document).unwrap();
     let root_id = tree.get_root_id();
-
-    decode_str(&mut tree, root_id, document).unwrap();
 
     let root_instance = tree.get_instance(root_id).unwrap();
     let descendant = tree.get_instance(root_instance.get_children_ids()[0]).unwrap();
@@ -294,10 +260,8 @@ fn with_cframe() {
         </roblox>
     "#;
 
-    let mut tree = new_data_model();
+    let tree = rbx_xml::from_str(document).unwrap();
     let root_id = tree.get_root_id();
-
-    decode_str(&mut tree, root_id, document).expect("should work D:");
 
     let root_instance = tree.get_instance(root_id).unwrap();
     let descendant = tree.get_instance(root_instance.get_children_ids()[0]).unwrap();
@@ -331,10 +295,8 @@ fn with_ref_some() {
         </roblox>
     "#;
 
-    let mut tree = new_data_model();
+    let tree = rbx_xml::from_str(document).unwrap();
     let root_id = tree.get_root_id();
-
-    decode_str(&mut tree, root_id, document).unwrap();
 
     let root_instance = tree.get_instance(root_id).unwrap();
     let target_instance_id = root_instance.get_children_ids()[0];
@@ -366,10 +328,8 @@ fn with_ref_none() {
         </roblox>
     "#;
 
-    let mut tree = new_data_model();
+    let tree = rbx_xml::from_str(document).unwrap();
     let root_id = tree.get_root_id();
-
-    decode_str(&mut tree, root_id, document).expect("should work D:");
 
     let root_instance = tree.get_instance(root_id).unwrap();
     let descendant = tree.get_instance(root_instance.get_children_ids()[0]).unwrap();

--- a/rbx_xml/tests/errors.rs
+++ b/rbx_xml/tests/errors.rs
@@ -1,9 +1,4 @@
-use std::{
-    collections::HashMap,
-    mem::size_of,
-};
-
-use rbx_dom_weak::{RbxTree, RbxInstanceProperties};
+use std::mem::size_of;
 
 #[test]
 fn errors_are_small() {
@@ -15,7 +10,7 @@ fn errors_are_small() {
 fn first_line_bad_xml() {
     let doc = "hi";
 
-    let err = rbx_xml::from_str(doc).unwrap_err();
+    let err = rbx_xml::from_str_default(doc).unwrap_err();
 
     assert_eq!(err.line(), 1);
     assert_eq!(err.column(), 0);
@@ -25,7 +20,7 @@ fn first_line_bad_xml() {
 fn bad_version() {
     let doc = r#"<roblox version="3"></roblox>"#;
 
-    let err = rbx_xml::from_str(doc).unwrap_err();
+    let err = rbx_xml::from_str_default(doc).unwrap_err();
 
     assert_eq!(err.line(), 1);
     assert_eq!(err.column(), 0);
@@ -37,7 +32,7 @@ fn second_line_gunk() {
         <asfk />
     </roblox>"#;
 
-    let err = rbx_xml::from_str(doc).unwrap_err();
+    let err = rbx_xml::from_str_default(doc).unwrap_err();
 
     assert_eq!(err.line(), 2);
     assert_eq!(err.column(), 8);

--- a/rbx_xml/tests/errors.rs
+++ b/rbx_xml/tests/errors.rs
@@ -5,16 +5,6 @@ use std::{
 
 use rbx_dom_weak::{RbxTree, RbxInstanceProperties};
 
-fn new_data_model() -> RbxTree {
-    let root = RbxInstanceProperties {
-        name: "DataModel".to_string(),
-        class_name: "DataModel".to_string(),
-        properties: HashMap::new(),
-    };
-
-    RbxTree::new(root)
-}
-
 #[test]
 fn errors_are_small() {
     assert!(size_of::<rbx_xml::DecodeError>() <= 8);
@@ -25,10 +15,7 @@ fn errors_are_small() {
 fn first_line_bad_xml() {
     let doc = "hi";
 
-    let mut tree = new_data_model();
-    let root_id = tree.get_root_id();
-
-    let err = rbx_xml::decode_str(&mut tree, root_id, doc).unwrap_err();
+    let err = rbx_xml::from_str(doc).unwrap_err();
 
     assert_eq!(err.line(), 1);
     assert_eq!(err.column(), 0);
@@ -38,10 +25,7 @@ fn first_line_bad_xml() {
 fn bad_version() {
     let doc = r#"<roblox version="3"></roblox>"#;
 
-    let mut tree = new_data_model();
-    let root_id = tree.get_root_id();
-
-    let err = rbx_xml::decode_str(&mut tree, root_id, doc).unwrap_err();
+    let err = rbx_xml::from_str(doc).unwrap_err();
 
     assert_eq!(err.line(), 1);
     assert_eq!(err.column(), 0);
@@ -53,10 +37,7 @@ fn second_line_gunk() {
         <asfk />
     </roblox>"#;
 
-    let mut tree = new_data_model();
-    let root_id = tree.get_root_id();
-
-    let err = rbx_xml::decode_str(&mut tree, root_id, doc).unwrap_err();
+    let err = rbx_xml::from_str(doc).unwrap_err();
 
     assert_eq!(err.line(), 2);
     assert_eq!(err.column(), 8);

--- a/rbx_xml/tests/fire.rs
+++ b/rbx_xml/tests/fire.rs
@@ -1,25 +1,13 @@
-use rbx_dom_weak::{RbxInstanceProperties, RbxValue, RbxTree};
+use rbx_dom_weak::RbxValue;
 
 static TEST_FILE: &[u8] = include_bytes!("../test-files/fire.rbxmx");
-
-fn new_test_tree() -> RbxTree {
-    let root = RbxInstanceProperties {
-        name: "Folder".to_string(),
-        class_name: "Folder".to_string(),
-        properties: Default::default(),
-    };
-
-    RbxTree::new(root)
-}
 
 #[test]
 fn fire_weird_properties() {
     let _ = env_logger::try_init();
 
-    let mut tree = new_test_tree();
+    let tree = rbx_xml::from_reader(TEST_FILE).unwrap();
     let root_id = tree.get_root_id();
-
-    rbx_xml::decode(&mut tree, root_id, TEST_FILE).unwrap();
 
     let root_instance = tree.get_instance(root_id).unwrap();
     let fire_id = root_instance.get_children_ids()[0];

--- a/rbx_xml/tests/fire.rs
+++ b/rbx_xml/tests/fire.rs
@@ -6,7 +6,7 @@ static TEST_FILE: &[u8] = include_bytes!("../test-files/fire.rbxmx");
 fn fire_weird_properties() {
     let _ = env_logger::try_init();
 
-    let tree = rbx_xml::from_reader(TEST_FILE).unwrap();
+    let tree = rbx_xml::from_reader_default(TEST_FILE).unwrap();
     let root_id = tree.get_root_id();
 
     let root_instance = tree.get_instance(root_id).unwrap();

--- a/rbx_xml/tests/referent.rs
+++ b/rbx_xml/tests/referent.rs
@@ -1,6 +1,6 @@
 use std::io::Cursor;
 
-use rbx_dom_weak::{RbxInstanceProperties, RbxValue, RbxTree};
+use rbx_dom_weak::{RbxValue, RbxTree};
 
 static TEST_FILE: &[u8] = include_bytes!("../test-files/part-referent.rbxmx");
 
@@ -26,7 +26,7 @@ fn assert_referents_sound(tree: &RbxTree) {
 fn referents_work() {
     let _ = env_logger::try_init();
 
-    let first_tree = rbx_xml::from_reader(TEST_FILE).unwrap();
+    let first_tree = rbx_xml::from_reader_default(TEST_FILE).unwrap();
     let root_id = first_tree.get_root_id();
 
     assert_referents_sound(&first_tree);
@@ -35,10 +35,9 @@ fn referents_work() {
     let model_id = root_instance.get_children_ids()[0];
 
     let mut buffer = Vec::new();
-    rbx_xml::to_writer(&first_tree, &[model_id], Cursor::new(&mut buffer)).unwrap();
+    rbx_xml::to_writer_default(Cursor::new(&mut buffer), &first_tree, &[model_id]).unwrap();
 
-    let second_tree = rbx_xml::from_reader(buffer.as_slice()).unwrap();
-    let new_root_id = second_tree.get_root_id();
+    let second_tree = rbx_xml::from_reader_default(buffer.as_slice()).unwrap();
 
     assert_referents_sound(&second_tree);
 }

--- a/rbx_xml/tests/round_trip.rs
+++ b/rbx_xml/tests/round_trip.rs
@@ -33,17 +33,15 @@ fn round_trip() {
     let _ = env_logger::try_init();
 
     for (index, model_source) in TEST_MODELS.iter().enumerate() {
-        let mut tree = new_test_tree();
-        let root_id = tree.get_root_id();
-
         info!("Decoding #{}...", index);
-        rbx_xml::decode_str(&mut tree, root_id, *model_source).unwrap();
+        let tree = rbx_xml::from_str(model_source).unwrap();
+        let root_id = tree.get_root_id();
 
         info!("Encoding #{}...", index);
         let mut buffer = Vec::new();
-        rbx_xml::encode(&tree, &[root_id], Cursor::new(&mut buffer)).unwrap();
+        rbx_xml::to_writer(&tree, &[root_id], Cursor::new(&mut buffer)).unwrap();
 
         info!("Re-Decoding #{}...", index);
-        rbx_xml::decode(&mut tree, root_id, buffer.as_slice()).unwrap();
+        rbx_xml::from_reader(buffer.as_slice()).unwrap();
     }
 }

--- a/rbx_xml/tests/round_trip.rs
+++ b/rbx_xml/tests/round_trip.rs
@@ -1,10 +1,6 @@
-use std::{
-    io::Cursor,
-    collections::HashMap,
-};
+use std::io::Cursor;
 
 use log::info;
-use rbx_dom_weak::{RbxInstanceProperties, RbxTree};
 
 static TEST_MODELS: &[&str] = &[
     include_str!("../test-files/baseplate.rbxlx"),
@@ -18,30 +14,20 @@ static TEST_MODELS: &[&str] = &[
     include_str!("../test-files/terrain.rbxmx"),
 ];
 
-fn new_test_tree() -> RbxTree {
-    let root = RbxInstanceProperties {
-        name: "Folder".to_string(),
-        class_name: "Folder".to_string(),
-        properties: HashMap::new(),
-    };
-
-    RbxTree::new(root)
-}
-
 #[test]
 fn round_trip() {
     let _ = env_logger::try_init();
 
     for (index, model_source) in TEST_MODELS.iter().enumerate() {
         info!("Decoding #{}...", index);
-        let tree = rbx_xml::from_str(model_source).unwrap();
+        let tree = rbx_xml::from_str_default(model_source).unwrap();
         let root_id = tree.get_root_id();
 
         info!("Encoding #{}...", index);
         let mut buffer = Vec::new();
-        rbx_xml::to_writer(&tree, &[root_id], Cursor::new(&mut buffer)).unwrap();
+        rbx_xml::to_writer_default(Cursor::new(&mut buffer), &tree, &[root_id]).unwrap();
 
         info!("Re-Decoding #{}...", index);
-        rbx_xml::from_reader(buffer.as_slice()).unwrap();
+        rbx_xml::from_reader_default(buffer.as_slice()).unwrap();
     }
 }

--- a/rbx_xml/tests/value_conversion.rs
+++ b/rbx_xml/tests/value_conversion.rs
@@ -1,25 +1,13 @@
-use rbx_dom_weak::{RbxInstanceProperties, RbxValue, RbxTree};
+use rbx_dom_weak::RbxValue;
 
 static TEST_FILE: &[u8] = include_bytes!("../test-files/number-value-int32.rbxmx");
-
-fn new_test_tree() -> RbxTree {
-    let root = RbxInstanceProperties {
-        name: "Folder".to_string(),
-        class_name: "Folder".to_string(),
-        properties: Default::default(),
-    };
-
-    RbxTree::new(root)
-}
 
 #[test]
 fn f32_to_f64() {
     let _ = env_logger::try_init();
 
-    let mut tree = new_test_tree();
+    let tree = rbx_xml::from_reader(TEST_FILE).unwrap();
     let root_id = tree.get_root_id();
-
-    rbx_xml::decode(&mut tree, root_id, TEST_FILE).unwrap();
 
     let root_instance = tree.get_instance(root_id).unwrap();
     let value_id = root_instance.get_children_ids()[0];

--- a/rbx_xml/tests/value_conversion.rs
+++ b/rbx_xml/tests/value_conversion.rs
@@ -6,7 +6,7 @@ static TEST_FILE: &[u8] = include_bytes!("../test-files/number-value-int32.rbxmx
 fn f32_to_f64() {
     let _ = env_logger::try_init();
 
-    let tree = rbx_xml::from_reader(TEST_FILE).unwrap();
+    let tree = rbx_xml::from_reader_default(TEST_FILE).unwrap();
     let root_id = tree.get_root_id();
 
     let root_instance = tree.get_instance(root_id).unwrap();


### PR DESCRIPTION
This PR rewrites the rbx_xml public API to be configurable and to improve its ergonomics.

The new base APIs are:
```rust
fn from_reader<R: Read>(
    reader: R,
    options: DecodeOptions,
) -> Result<RbxTree, DecodeError>;

fn to_writer<W: Write>(
    writer: W,
    tree: &RbxTree,
    ids: &[RbxId],
    options: EncodeOptions,
) -> Result<RbxTree, EncodeError>;
```

Parameters were shaved out of what was `rbx_xml::decode` since the reader now decode into a new tree and expects you to move it into an existing tree if you have one with `RbxTree::move_instance`. This may prove to be a little slower, but makes it easier to handle error scenarios and makes small examples simpler.

The encoder API still takes a lot of parameters. This is tricky to simplify because of the way places are serialized, since they ignore their root instance.

There's still kind of a sharp corner to this API because of the split of whether the root instance is included when serializing. I'm unsure if there's a good way to fix this without changing rbx_dom_weak to support multiple root instances.