### PR TITLE
Fix type conversions in  rbx_xml serialization

### DIFF
--- a/rbx_xml/test-files/part.rbxmx
+++ b/rbx_xml/test-files/part.rbxmx
@@ -1,0 +1,80 @@
+<roblox xmlns:xmime="http://www.w3.org/2005/05/xmlmime" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.roblox.com/roblox.xsd" version="4">
+	<Meta name="ExplicitAutoJoints">true</Meta>
+	<External>null</External>
+	<External>nil</External>
+	<Item class="Part" referent="RBX24C8D716BF774BABB140C41ABCE9B148">
+		<Properties>
+			<bool name="Anchored">false</bool>
+			<float name="BackParamA">-0.5</float>
+			<float name="BackParamB">0.5</float>
+			<token name="BackSurface">0</token>
+			<token name="BackSurfaceInput">0</token>
+			<float name="BottomParamA">-0.5</float>
+			<float name="BottomParamB">0.5</float>
+			<token name="BottomSurface">0</token>
+			<token name="BottomSurfaceInput">0</token>
+			<CoordinateFrame name="CFrame">
+				<X>-6</X>
+				<Y>0.500001013</Y>
+				<Z>-11</Z>
+				<R00>1</R00>
+				<R01>0</R01>
+				<R02>0</R02>
+				<R10>0</R10>
+				<R11>1</R11>
+				<R12>0</R12>
+				<R20>0</R20>
+				<R21>0</R21>
+				<R22>1</R22>
+			</CoordinateFrame>
+			<bool name="CanCollide">true</bool>
+			<bool name="CastShadow">true</bool>
+			<int name="CollisionGroupId">0</int>
+			<Color3uint8 name="Color3uint8">4288914085</Color3uint8>
+			<PhysicalProperties name="CustomPhysicalProperties">
+				<CustomPhysics>false</CustomPhysics>
+			</PhysicalProperties>
+			<float name="FrontParamA">-0.5</float>
+			<float name="FrontParamB">0.5</float>
+			<token name="FrontSurface">0</token>
+			<token name="FrontSurfaceInput">0</token>
+			<float name="LeftParamA">-0.5</float>
+			<float name="LeftParamB">0.5</float>
+			<token name="LeftSurface">0</token>
+			<token name="LeftSurfaceInput">0</token>
+			<bool name="Locked">false</bool>
+			<bool name="Massless">false</bool>
+			<token name="Material">256</token>
+			<string name="Name">Part</string>
+			<float name="Reflectance">0</float>
+			<float name="RightParamA">-0.5</float>
+			<float name="RightParamB">0.5</float>
+			<token name="RightSurface">0</token>
+			<token name="RightSurfaceInput">0</token>
+			<int name="RootPriority">0</int>
+			<Vector3 name="RotVelocity">
+				<X>0</X>
+				<Y>0</Y>
+				<Z>0</Z>
+			</Vector3>
+			<BinaryString name="Tags"></BinaryString>
+			<float name="TopParamA">-0.5</float>
+			<float name="TopParamB">0.5</float>
+			<token name="TopSurface">0</token>
+			<token name="TopSurfaceInput">0</token>
+			<float name="Transparency">0</float>
+			<Vector3 name="Velocity">
+				<X>0</X>
+				<Y>0</Y>
+				<Z>0</Z>
+			</Vector3>
+			<token name="formFactorRaw">1</token>
+			<token name="shape">1</token>
+			<Vector3 name="size">
+				<X>4</X>
+				<Y>1</Y>
+				<Z>2</Z>
+			</Vector3>
+		</Properties>
+	</Item>
+</roblox>

--- a/rbx_xml/tests/parts.rs
+++ b/rbx_xml/tests/parts.rs
@@ -1,0 +1,54 @@
+use std::str;
+
+use rbx_dom_weak::RbxValue;
+
+static TEST_FILE: &[u8] = include_bytes!("../test-files/part.rbxmx");
+
+fn float_approx_eq(a: f32, b: f32) {
+    assert!((a - b).abs() < 0.001);
+}
+
+fn color3_approx_eq(a: [f32; 3], b: [f32; 3]) {
+    float_approx_eq(a[0], b[0]);
+    float_approx_eq(a[1], b[1]);
+    float_approx_eq(a[2], b[2]);
+}
+
+#[test]
+fn part_color() {
+    let _ = env_logger::try_init();
+
+    let tree = rbx_xml::from_reader_default(TEST_FILE).unwrap();
+    let root_id = tree.get_root_id();
+
+    let root_instance = tree.get_instance(root_id).unwrap();
+    let part_id = root_instance.get_children_ids()[0];
+    let part = tree.get_instance(part_id).unwrap();
+
+    let color = part.properties.get("Color")
+        .expect("Missing 'Color' property");
+
+    match color {
+        RbxValue::Color3 { value } => {
+            color3_approx_eq(*value, [0.639216, 0.635294, 0.647059]);
+        }
+        _ => panic!("Color property wrong type, expected Color3, got value {:?}", color)
+    }
+
+    let mut buffer = Vec::new();
+    rbx_xml::to_writer_default(&mut buffer, &tree, &[part_id]).unwrap();
+
+    // The serialized form should contain a Color3uint8 property named
+    // Color3uint8. This is a kludge to check that it does!
+    let as_str = str::from_utf8(&buffer).unwrap();
+    assert!(as_str.contains(r#"<Color3uint8 name="Color3uint8""#));
+
+    let new_tree = rbx_xml::from_reader_default(buffer.as_slice()).unwrap();
+    let new_root_id = new_tree.get_root_id();
+
+    let new_root_instance = new_tree.get_instance(new_root_id).unwrap();
+    let new_part_id = new_root_instance.get_children_ids()[0];
+    let new_part = new_tree.get_instance(new_part_id).unwrap();
+
+    assert_eq!(part.properties, new_part.properties);
+}


### PR DESCRIPTION
Fixes #55.

This PR fixes how rbx_xml's serializer converts types when serializing. Instead of trying to convert to the type given by the canonical property descriptor, we'll instead try to convert to the type given by the _serialized_ property descriptor. This is the one referred to by the `serialized_name` field of a property descriptor.