### PR TITLE
Make failed type conversions in serialization cause errors

### DIFF
--- a/rbx_xml/CHANGELOG.md
+++ b/rbx_xml/CHANGELOG.md
@@ -1,6 +1,8 @@
 # rbx_xml Changelog
 
 ## Unreleased
+* Fixed type conversion when serializing properties whose serialized type differs from its canonical type ([#56](https://github.com/LPGhatguy/rbx-dom/pull/56))
+* Changed type conversion failures when serializing to elevate to serialization errors ([#58](https://github.com/LPGhatguy/rbx-dom/pull/58))
 
 ## 0.7.0 (2019-05-12)
 * Breaking: changed API dramatically to make deserializing instances easier

--- a/rbx_xml/src/deserializer.rs
+++ b/rbx_xml/src/deserializer.rs
@@ -374,7 +374,13 @@ fn deserialize_properties<R: Read>(
 
                     let value = match xml_value.try_convert_ref(value_type) {
                         RbxValueConversion::Converted(value) => value,
-                        RbxValueConversion::Unnecessary | RbxValueConversion::Failed => xml_value,
+                        RbxValueConversion::Unnecessary => xml_value,
+                        RbxValueConversion::Failed => return Err(reader.error(DecodeErrorKind::UnsupportedPropertyConversion {
+                            class_name: class_name.clone(),
+                            property_name: descriptor.name().to_string(),
+                            expected_type: value_type,
+                            actual_type: xml_value.get_type(),
+                        })),
                     };
 
                     value


### PR DESCRIPTION
Closes #57.

This PR changes rbx_xml to turn property type conversion failures (ie irreconcilable differences from the reflection database) into serialization/deserialization failures. This makes rbx_xml more strict and should help us catch problems quicker down the line.