### PR TITLE
Add real configuration options to rbx_xml

### DIFF
--- a/rbx_xml/src/error.rs
+++ b/rbx_xml/src/error.rs
@@ -72,6 +72,10 @@ pub(crate) enum DecodeErrorKind {
     UnexpectedEof,
     UnexpectedXmlEvent(xml::reader::XmlEvent),
     MissingAttribute(&'static str),
+    UnknownProperty {
+        class_name: String,
+        property_name: String,
+    },
     UnknownPropertyType(String),
     InvalidContent(&'static str),
     NameMustBeString(RbxValueType),
@@ -97,6 +101,8 @@ impl fmt::Display for DecodeErrorKind {
             UnexpectedEof => write!(output, "Unexpected end-of-file"),
             UnexpectedXmlEvent(event) => write!(output, "Unexpected XML event {:?}", event),
             MissingAttribute(attribute_name) => write!(output, "Missing attribute '{}'", attribute_name),
+            UnknownProperty { class_name, property_name } =>
+                write!(output, "Property {}.{} is unknown", class_name, property_name),
             UnknownPropertyType(prop_name) => write!(output, "Unknown property type '{}'", prop_name),
             InvalidContent(explain) => write!(output, "Invalid text content: {}", explain),
             NameMustBeString(ty) => write!(output, "The 'Name' property must be of type String, but it was {:?}", ty),
@@ -121,6 +127,7 @@ impl std::error::Error for DecodeErrorKind {
             | UnexpectedEof
             | UnexpectedXmlEvent(_)
             | MissingAttribute(_)
+            | UnknownProperty { .. }
             | UnknownPropertyType(_)
             | InvalidContent(_)
             | NameMustBeString(_)

--- a/rbx_xml/src/error.rs
+++ b/rbx_xml/src/error.rs
@@ -190,6 +190,10 @@ pub(crate) enum EncodeErrorKind {
     Io(io::Error),
     Xml(xml::writer::Error),
 
+    UnknownProperty {
+        class_name: String,
+        property_name: String,
+    },
     UnsupportedPropertyType(RbxValueType),
     UnsupportedPropertyConversion {
         class_name: String,
@@ -207,6 +211,8 @@ impl fmt::Display for EncodeErrorKind {
             Io(err) => write!(output, "{}", err),
             Xml(err) => write!(output, "{}", err),
 
+            UnknownProperty { class_name, property_name } =>
+                write!(output, "Property {}.{} is unknown", class_name, property_name),
             UnsupportedPropertyType(ty) => write!(output, "Properties of type {:?} cannot be encoded yet", ty),
             UnsupportedPropertyConversion { class_name, property_name, expected_type, actual_type } =>
                 write!(output, "Property {}.{} is expected to be of type {:?}, but it was of type {:?}",
@@ -223,7 +229,9 @@ impl std::error::Error for EncodeErrorKind {
             Io(err) => Some(err),
             Xml(err) => Some(err),
 
-            UnsupportedPropertyType(_) | UnsupportedPropertyConversion { .. } => None,
+            UnknownProperty { .. }
+            | UnsupportedPropertyType(_)
+            | UnsupportedPropertyConversion { .. } => None,
         }
     }
 }

--- a/rbx_xml/src/lib.rs
+++ b/rbx_xml/src/lib.rs
@@ -142,7 +142,7 @@ use crate::{
 
 pub use crate::{
     error::{EncodeError, DecodeError},
-    deserializer::DecodeOptions,
+    deserializer::{DecodeOptions, DecodePropertyBehavior},
     serializer::EncodeOptions,
 };
 

--- a/rbx_xml/src/lib.rs
+++ b/rbx_xml/src/lib.rs
@@ -143,7 +143,7 @@ use crate::{
 pub use crate::{
     error::{EncodeError, DecodeError},
     deserializer::{DecodeOptions, DecodePropertyBehavior},
-    serializer::EncodeOptions,
+    serializer::{EncodeOptions, EncodePropertyBehavior},
 };
 
 /// Decodes an XML-format model or place from something that implements the

--- a/rbx_xml/tests/deserializer_options.rs
+++ b/rbx_xml/tests/deserializer_options.rs
@@ -1,0 +1,145 @@
+use rbx_dom_weak::RbxValue;
+use rbx_xml::{DecodeOptions, DecodePropertyBehavior};
+
+static TEST_DOCUMENT: &str = r#"
+    <roblox version="4">
+        <Item class="StringValue" referent="A">
+            <Properties>
+                <string name="Name">A</string>
+                <string name="Value">the value</string>
+                <string name="UnknownProperty">oh nooo</string>
+            </Properties>
+        </Item>
+    </roblox>
+"#;
+
+#[test]
+fn ignore_unknown_properties() {
+    let options = DecodeOptions::new()
+        .property_behavior(DecodePropertyBehavior::IgnoreUnknown);
+
+    let tree = rbx_xml::from_str(TEST_DOCUMENT, options)
+        .expect("Couldn't decode tree");
+
+    let root_instance = tree.get_instance(tree.get_root_id()).unwrap();
+
+    let child_id = root_instance.get_children_ids()[0];
+    let child_instance = tree.get_instance(child_id).unwrap();
+
+    assert_eq!(child_instance.name, "A");
+
+    assert_eq!(
+        child_instance.properties.get("Value"),
+        Some(&RbxValue::String {
+            value: "the value".to_owned(),
+        }),
+    );
+
+    assert_eq!(
+        child_instance.properties.get("UnknownProperty"),
+        None,
+    );
+}
+
+#[test]
+fn read_unknown_properties() {
+    let options = DecodeOptions::new()
+        .property_behavior(DecodePropertyBehavior::ReadUnknown);
+
+    let tree = rbx_xml::from_str(TEST_DOCUMENT, options)
+        .expect("Couldn't decode tree");
+
+    let root_instance = tree.get_instance(tree.get_root_id()).unwrap();
+
+    let child_id = root_instance.get_children_ids()[0];
+    let child_instance = tree.get_instance(child_id).unwrap();
+
+    assert_eq!(child_instance.name, "A");
+
+    assert_eq!(
+        child_instance.properties.get("Value"),
+        Some(&RbxValue::String {
+            value: "the value".to_owned(),
+        }),
+    );
+
+    assert_eq!(
+        child_instance.properties.get("UnknownProperty"),
+        Some(&RbxValue::String {
+            value: "oh nooo".to_owned(),
+        }),
+    );
+}
+
+#[test]
+fn error_on_unknown_properties() {
+    let options = DecodeOptions::new()
+        .property_behavior(DecodePropertyBehavior::ErrorOnUnknown);
+
+    rbx_xml::from_str(TEST_DOCUMENT, options)
+        .expect_err("Expected tree to fail to deserialize");
+}
+
+#[test]
+fn no_reflection() {
+    let options = DecodeOptions::new()
+        .property_behavior(DecodePropertyBehavior::NoReflection);
+
+    let tree = rbx_xml::from_str(TEST_DOCUMENT, options)
+        .expect("Couldn't decode tree");
+
+    let root_instance = tree.get_instance(tree.get_root_id()).unwrap();
+
+    let child_id = root_instance.get_children_ids()[0];
+    let child_instance = tree.get_instance(child_id).unwrap();
+
+    assert_eq!(child_instance.name, "A");
+
+    assert_eq!(
+        child_instance.properties.get("Value"),
+        Some(&RbxValue::String {
+            value: "the value".to_owned(),
+        }),
+    );
+
+    assert_eq!(
+        child_instance.properties.get("UnknownProperty"),
+        Some(&RbxValue::String {
+            value: "oh nooo".to_owned(),
+        }),
+    );
+}
+
+#[test]
+fn no_reflection_renamed_value() {
+    let document = r#"
+        <roblox version="4">
+            <Item class="Part" referent="A">
+                <Properties>
+                    <string name="Name">A</string>
+                    <token name="formFactorRaw">1</token>
+                </Properties>
+            </Item>
+        </roblox>
+    "#;
+
+    let options = DecodeOptions::new()
+        .property_behavior(DecodePropertyBehavior::NoReflection);
+
+    let tree = rbx_xml::from_str(document, options)
+        .expect("Couldn't decode tree");
+
+    let root_instance = tree.get_instance(tree.get_root_id()).unwrap();
+
+    let child_id = root_instance.get_children_ids()[0];
+    let child_instance = tree.get_instance(child_id).unwrap();
+
+    assert_eq!(child_instance.name, "A");
+
+    assert_eq!(
+        child_instance.properties.get("formFactorRaw"),
+        Some(&RbxValue::Enum {
+            value: 1,
+        }),
+    );
+}

--- a/rbx_xml/tests/serializer_options.rs
+++ b/rbx_xml/tests/serializer_options.rs
@@ -1,0 +1,94 @@
+use std::collections::HashMap;
+
+use rbx_dom_weak::{RbxValue, RbxTree, RbxInstanceProperties};
+use rbx_xml::{EncodeOptions, EncodePropertyBehavior};
+
+fn make_test_tree() -> RbxTree {
+    let mut properties = HashMap::new();
+
+    properties.insert("FormFactor".to_owned(), RbxValue::Enum {
+        value: 1,
+    });
+
+    properties.insert("UnknownProperty".to_owned(), RbxValue::String {
+        value: "ahhhh".to_owned(),
+    });
+
+    RbxTree::new(RbxInstanceProperties {
+        name: "Foo".to_owned(),
+        class_name: "Part".to_owned(),
+        properties,
+    })
+}
+
+#[test]
+fn ignore_unknown_properties() {
+    let options = EncodeOptions::new()
+        .property_behavior(EncodePropertyBehavior::IgnoreUnknown);
+
+    let tree = make_test_tree();
+
+    let mut output = Vec::new();
+    rbx_xml::to_writer(&mut output, &tree, &[tree.get_root_id()], options)
+        .expect("Couldn't encode tree");
+
+    let output = String::from_utf8(output)
+        .expect("Couldn't convert output to UTF-8");
+
+    assert!(output.contains("formFactorRaw"));
+    assert!(!output.contains("FormFactor"));
+    assert!(!output.contains("UnknownProperty"));
+    assert!(!output.contains("ahhhh"));
+}
+
+#[test]
+fn write_unknown_properties() {
+    let options = EncodeOptions::new()
+        .property_behavior(EncodePropertyBehavior::WriteUnknown);
+
+    let tree = make_test_tree();
+
+    let mut output = Vec::new();
+    rbx_xml::to_writer(&mut output, &tree, &[tree.get_root_id()], options)
+        .expect("Couldn't encode tree");
+
+    let output = String::from_utf8(output)
+        .expect("Couldn't convert output to UTF-8");
+
+    assert!(output.contains("formFactorRaw"));
+    assert!(!output.contains("FormFactor"));
+    assert!(output.contains("UnknownProperty"));
+    assert!(output.contains("ahhhh"));
+}
+
+#[test]
+fn error_on_unknown_properties() {
+    let options = EncodeOptions::new()
+        .property_behavior(EncodePropertyBehavior::ErrorOnUnknown);
+
+    let tree = make_test_tree();
+
+    let mut output = Vec::new();
+    rbx_xml::to_writer(&mut output, &tree, &[tree.get_root_id()], options)
+        .expect_err("Successfully encoded malformed tree");
+}
+
+#[test]
+fn no_reflection() {
+    let options = EncodeOptions::new()
+        .property_behavior(EncodePropertyBehavior::NoReflection);
+
+    let tree = make_test_tree();
+
+    let mut output = Vec::new();
+    rbx_xml::to_writer(&mut output, &tree, &[tree.get_root_id()], options)
+        .expect("Couldn't encode tree");
+
+    let output = String::from_utf8(output)
+        .expect("Couldn't convert output to UTF-8");
+
+    assert!(!output.contains("formFactorRaw"));
+    assert!(output.contains("FormFactor"));
+    assert!(output.contains("UnknownProperty"));
+    assert!(output.contains("ahhhh"));
+}


### PR DESCRIPTION
This PR takes advantage of `DecodeOptions` and `EncodeOptions` to actually let the user set what kind of behaviors they want.

Options are:
- Ignore unrecognized properties (the default)
- Read/write unrecognized properties as-is (will probably be used by Rojo, at least in the short term)
- Error on unrecognized properties
- Completely turn off reflection and deserialize everything as-is